### PR TITLE
Add default timeout=30s for subprocess.check_output.

### DIFF
--- a/prometheus_hardware_exporter/utils.py
+++ b/prometheus_hardware_exporter/utils.py
@@ -61,7 +61,9 @@ class Command:
         full_command = " ".join([prefix, command, args]).strip()
         try:
             logger.debug("Running command: %s", full_command)
-            result.data = subprocess.check_output(full_command, shell=True).decode().strip()
+            result.data = (
+                subprocess.check_output(full_command, shell=True, timeout=30).decode().strip()
+            )
         except subprocess.CalledProcessError as err:
             logger.error(err)
             result.error = err


### PR DESCRIPTION
Add default timeout to 30s for `subprocess.check_output.`

Closes: #9 