### PR TITLE
Add TTL cache to redfish discover method

### DIFF
--- a/prometheus_hardware_exporter/__main__.py
+++ b/prometheus_hardware_exporter/__main__.py
@@ -16,7 +16,13 @@ from .collector import (
     RedfishCollector,
     SsaCLICollector,
 )
-from .config import DEFAULT_CONFIG, Config
+from .config import (
+    DEFAULT_CONFIG,
+    DEFAULT_REDFISH_CLIENT_MAX_RETRY,
+    DEFAULT_REDFISH_CLIENT_TIMEOUT,
+    DEFAULT_REDFISH_DISCOVER_CACHE_TTL,
+    Config,
+)
 from .exporter import Exporter
 
 logger = logging.getLogger(__name__)
@@ -112,6 +118,27 @@ def parse_command_line() -> argparse.Namespace:
         help="Enable redfish collector (default: disabled)",
         action="store_true",
     )
+    parser.add_argument(
+        "--redfish-client-timeout",
+        help="Redfish client timeout in seconds for initial connection (default: 3) ",
+        default=DEFAULT_REDFISH_CLIENT_TIMEOUT,
+        type=int,
+    )
+    parser.add_argument(
+        "--redfish-client-max-retry",
+        help="Number of times the redfish client will retry after timeout (default: 1) ",
+        default=DEFAULT_REDFISH_CLIENT_MAX_RETRY,
+        type=int,
+    )
+    parser.add_argument(
+        "--redfish-discover-cache-ttl",
+        help=(
+            "How long should the cached redfish discovery services "
+            "be stored in seconds (default: 86400) "
+        ),
+        default=DEFAULT_REDFISH_DISCOVER_CACHE_TTL,
+        type=int,
+    )
     args = parser.parse_args()
 
     return args
@@ -166,6 +193,9 @@ def main() -> None:
             redfish_username=namespace.redfish_username,
             redfish_password=namespace.redfish_password,
             ipmi_sel_interval=namespace.ipmi_sel_interval,
+            redfish_client_timeout=namespace.redfish_client_timeout,
+            redfish_client_max_retry=namespace.redfish_client_max_retry,
+            redfish_discover_cache_ttl=namespace.redfish_discover_cache_ttl,
         )
 
     # Start the exporter

--- a/prometheus_hardware_exporter/collector.py
+++ b/prometheus_hardware_exporter/collector.py
@@ -850,7 +850,10 @@ class SsaCLICollector(BlockingCollector):
 class RedfishCollector(BlockingCollector):
     """Collector for redfish status and data."""
 
-    redfish_helper = RedfishHelper()
+    def __init__(self, config: Config) -> None:
+        """Initialize RedfishHelper instance."""
+        super().__init__(config)
+        self.redfish_helper = RedfishHelper(self.config.redfish_discover_cache_ttl)
 
     @property
     def specifications(self) -> List[Specification]:
@@ -886,6 +889,8 @@ class RedfishCollector(BlockingCollector):
             host=redfish_host,
             username=redfish_username,
             password=redfish_password,
+            timeout=self.config.redfish_client_timeout,
+            max_retry=self.config.redfish_client_max_retry,
         )
         if not sensor_data:
             logger.error("Failed to get sensor data via redfish.")

--- a/prometheus_hardware_exporter/collector.py
+++ b/prometheus_hardware_exporter/collector.py
@@ -853,14 +853,7 @@ class RedfishCollector(BlockingCollector):
     def __init__(self, config: Config) -> None:
         """Initialize RedfishHelper instance."""
         super().__init__(config)
-        self.redfish_helper = RedfishHelper(
-            host=self.config.redfish_host,
-            username=self.config.redfish_username,
-            password=self.config.redfish_password,
-            timeout=self.config.redfish_client_timeout,
-            max_retry=self.config.redfish_client_max_retry,
-            discover_cache_ttl=self.config.redfish_discover_cache_ttl,
-        )
+        self.redfish_helper = RedfishHelper(config)
 
     @property
     def specifications(self) -> List[Specification]:

--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -1,10 +1,10 @@
 """Redfish collector."""
 from logging import getLogger
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import redfish
 import redfish_utilities
-from cachetools import TTLCache, cached
+from cachetools.func import ttl_cache
 from redfish.rest.v1 import (
     HttpClient,
     InvalidCredentialsError,
@@ -14,27 +14,36 @@ from redfish.rest.v1 import (
 
 logger = getLogger(__name__)
 
-# timeout in seconds for initial connection
-REDFISH_CLIENT_TIMEOUT = 3
-# Number of times a request will retry after a timeout
-REDFISH_CLIENT_MAX_RETRY = 1
 
-# maximum size of cache before old items are removed
-CACHE_MAXSIZE = 5
-# how long should the cache be stored in seconds
-CACHE_TTL = 86400
+# pylint: disable=R0903
+# pylint: disable=R0913
 
 
 class RedfishHelper:
     """Helper function for redfish."""
 
-    def get_sensor_data(self, host: str, username: str, password: str) -> Dict[str, List]:
+    def __init__(self, discover_cache_ttl: int) -> None:
+        """Initialize disover method with TTL value."""
+        self.discover = self.get_discover(discover_cache_ttl)
+
+    def get_sensor_data(
+        self, host: str, username: str, password: str, timeout: int, max_retry: int
+    ) -> Dict[str, List]:
         """Get sensor data.
+
+        Params:
+            host: redfish URL
+            username: username to login
+            password: password to login
+            timeout: redfish client timeout
+            max_retry: redfish client max retry
 
         Returns:
             sensor_data: a dictionary where key, value maps to chassis name, sensor data.
         """
-        data = self._get_sensor_data(host=host, username=username, password=password)
+        data = self._get_sensor_data(
+            host=host, username=username, password=password, timeout=timeout, max_retry=max_retry
+        )
         if not data:
             return {}
         output = {}
@@ -54,8 +63,21 @@ class RedfishHelper:
             output[name] = sensors
         return output
 
-    def _get_sensor_data(self, host: str, username: str, password: str) -> Optional[List[Any]]:
-        """Return sensor if sensor exists else None."""
+    def _get_sensor_data(
+        self, host: str, username: str, password: str, timeout: int, max_retry: int
+    ) -> Optional[List[Any]]:
+        """Return sensor if sensor exists else None.
+
+        Params:
+            host: redfish URL
+            username: username to login
+            password: password to login
+            timeout: redfish client timeout
+            max_retry: redfish client max retry
+
+        Returns:
+            sensors: List of dicts with details for each sensor
+        """
         sensors: Optional[List[Any]] = None
         redfish_obj: Optional[HttpClient] = None
         try:
@@ -63,8 +85,8 @@ class RedfishHelper:
                 base_url=host,
                 username=username,
                 password=password,
-                timeout=REDFISH_CLIENT_TIMEOUT,
-                max_retry=REDFISH_CLIENT_MAX_RETRY,
+                timeout=timeout,
+                max_retry=max_retry,
             )
             redfish_obj.login(auth="session")
             sensors = redfish_utilities.get_sensors(redfish_obj)
@@ -82,11 +104,21 @@ class RedfishHelper:
                 redfish_obj.logout()
         return sensors
 
-    @cached(cache=TTLCache(maxsize=CACHE_MAXSIZE, ttl=CACHE_TTL))
-    def discover(self) -> bool:
-        """Return true if redfish is been discovered."""
-        logger.info("Discovering redfish services")
-        services = redfish.discover_ssdp()
-        if len(services) == 0:
-            return False
-        return True
+    def get_discover(self, ttl: int) -> Callable:
+        """Return the cached discover function.
+
+        Passes the ttl value to the cache decorator at runtime.
+        """
+
+        @ttl_cache(ttl=ttl)
+        def _discover() -> bool:
+            """Return true if redfish services have been discovered."""
+            logger.info("Discovering redfish services...")
+            services = redfish.discover_ssdp()
+            if len(services) == 0:
+                logger.info("No redfish services discovered")
+                return False
+            logger.info("Discovered redfish services: %s", services)
+            return True
+
+        return _discover

--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -1,42 +1,32 @@
 """Redfish collector."""
 from logging import getLogger
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List
 
 import redfish
 import redfish_utilities
 from cachetools.func import ttl_cache
 from redfish.rest.v1 import (
-    HttpClient,
     InvalidCredentialsError,
     RetriesExhaustedError,
     SessionCreationError,
 )
 
+from prometheus_hardware_exporter.config import Config
+
 logger = getLogger(__name__)
-
-
-# pylint: disable=too-many-arguments
 
 
 class RedfishHelper:
     """Helper function for redfish."""
 
-    def __init__(
-        self,
-        host: str,
-        username: str,
-        password: str,
-        timeout: int,
-        max_retry: int,
-        discover_cache_ttl: int,
-    ) -> None:
+    def __init__(self, config: Config) -> None:
         """Initialize redfish login args and cache TTL value for discover method."""
-        self.host = host
-        self.username = username
-        self.password = password
-        self.timeout = timeout
-        self.max_retry = max_retry
-        self.discover = self.get_discover(discover_cache_ttl)
+        self.host = config.redfish_host
+        self.username = config.redfish_username
+        self.password = config.redfish_password
+        self.timeout = config.redfish_client_timeout
+        self.max_retry = config.redfish_client_max_retry
+        self.discover = self.get_discover(config.redfish_discover_cache_ttl)
 
     def get_sensor_data(self) -> Dict[str, List]:
         """Get sensor data.
@@ -44,45 +34,37 @@ class RedfishHelper:
         Returns:
             sensor_data: a dictionary where key, value maps to chassis name, sensor data.
         """
-        data = self._get_sensor_data()
-        if not data:
-            return {}
-        output = {}
-        for chassis in data:
-            name = str(chassis["ChassisName"])
-            sensors = []
-            for sensor in chassis["Readings"]:
-                reading: str = str(sensor["Reading"]) + (sensor["Units"] or "")
+        data = self._retrieve_redfish_sensor_data()
+        return self._map_sensor_data_to_chassis(data)
 
-                sensors.append(
-                    {
-                        "Sensor": sensor["Name"],
-                        "Reading": reading,
-                        "Health": sensor["Health"] or "N/A",
-                    }
-                )
-            output[name] = sensors
+    def _map_sensor_data_to_chassis(self, sensor_data: List[Any]) -> Dict[str, List]:
+        output = {}
+        for chassis in sensor_data:
+            output[str(chassis["ChassisName"])] = [
+                {
+                    "Sensor": sensor["Name"],
+                    "Reading": str(sensor["Reading"]) + (sensor["Units"] or ""),
+                    "Health": sensor["Health"] or "N/A",
+                }
+                for sensor in chassis["Readings"]
+            ]
         return output
 
-    def _get_sensor_data(self) -> Optional[List[Any]]:
+    def _retrieve_redfish_sensor_data(self) -> List[Any]:
         """Return sensor if sensor exists else None.
 
         Returns:
             sensors: List of dicts with details for each sensor
         """
-        sensors: Optional[List[Any]] = None
-        redfish_obj: Optional[HttpClient] = None
         try:
-            redfish_obj = redfish.redfish_client(
+            with redfish.redfish_client(
                 base_url=self.host,
                 username=self.username,
                 password=self.password,
                 timeout=self.timeout,
                 max_retry=self.max_retry,
-            )
-            redfish_obj.login(auth="session")
-            sensors = redfish_utilities.get_sensors(redfish_obj)
-            return sensors
+            ) as redfish_obj:
+                return redfish_utilities.get_sensors(redfish_obj)
         except (
             InvalidCredentialsError,
             SessionCreationError,
@@ -90,11 +72,7 @@ class RedfishHelper:
             RetriesExhaustedError,
         ) as err:
             logger.exception(err)
-        finally:
-            # Log out
-            if redfish_obj:
-                redfish_obj.logout()
-        return sensors
+        return []
 
     def get_discover(self, ttl: int) -> Callable:
         """Return the cached discover function.

--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -30,7 +30,7 @@ class RedfishHelper:
         max_retry: int,
         discover_cache_ttl: int,
     ) -> None:
-        """Initialize disover method with TTL value."""
+        """Initialize redfish login args and cache TTL value for discover method."""
         self.host = host
         self.username = username
         self.password = password

--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -15,35 +15,36 @@ from redfish.rest.v1 import (
 logger = getLogger(__name__)
 
 
-# pylint: disable=R0903
-# pylint: disable=R0913
+# pylint: disable=too-many-arguments
 
 
 class RedfishHelper:
     """Helper function for redfish."""
 
-    def __init__(self, discover_cache_ttl: int) -> None:
+    def __init__(
+        self,
+        host: str,
+        username: str,
+        password: str,
+        timeout: int,
+        max_retry: int,
+        discover_cache_ttl: int,
+    ) -> None:
         """Initialize disover method with TTL value."""
+        self.host = host
+        self.username = username
+        self.password = password
+        self.timeout = timeout
+        self.max_retry = max_retry
         self.discover = self.get_discover(discover_cache_ttl)
 
-    def get_sensor_data(
-        self, host: str, username: str, password: str, timeout: int, max_retry: int
-    ) -> Dict[str, List]:
+    def get_sensor_data(self) -> Dict[str, List]:
         """Get sensor data.
-
-        Params:
-            host: redfish URL
-            username: username to login
-            password: password to login
-            timeout: redfish client timeout
-            max_retry: redfish client max retry
 
         Returns:
             sensor_data: a dictionary where key, value maps to chassis name, sensor data.
         """
-        data = self._get_sensor_data(
-            host=host, username=username, password=password, timeout=timeout, max_retry=max_retry
-        )
+        data = self._get_sensor_data()
         if not data:
             return {}
         output = {}
@@ -63,17 +64,8 @@ class RedfishHelper:
             output[name] = sensors
         return output
 
-    def _get_sensor_data(
-        self, host: str, username: str, password: str, timeout: int, max_retry: int
-    ) -> Optional[List[Any]]:
+    def _get_sensor_data(self) -> Optional[List[Any]]:
         """Return sensor if sensor exists else None.
-
-        Params:
-            host: redfish URL
-            username: username to login
-            password: password to login
-            timeout: redfish client timeout
-            max_retry: redfish client max retry
 
         Returns:
             sensors: List of dicts with details for each sensor
@@ -82,11 +74,11 @@ class RedfishHelper:
         redfish_obj: Optional[HttpClient] = None
         try:
             redfish_obj = redfish.redfish_client(
-                base_url=host,
-                username=username,
-                password=password,
-                timeout=timeout,
-                max_retry=max_retry,
+                base_url=self.host,
+                username=self.username,
+                password=self.password,
+                timeout=self.timeout,
+                max_retry=self.max_retry,
             )
             redfish_obj.login(auth="session")
             sensors = redfish_utilities.get_sensors(redfish_obj)

--- a/prometheus_hardware_exporter/config.py
+++ b/prometheus_hardware_exporter/config.py
@@ -11,6 +11,9 @@ logger = getLogger(__name__)
 
 DEFAULT_CONFIG = os.path.join(os.environ.get("SNAP_DATA", "./"), "config.yaml")
 
+DEFAULT_REDFISH_CLIENT_TIMEOUT = 3
+DEFAULT_REDFISH_CLIENT_MAX_RETRY = 1
+DEFAULT_REDFISH_DISCOVER_CACHE_TTL = 86400
 
 # pylint: disable=E0213
 
@@ -27,6 +30,9 @@ class Config(BaseModel):
     redfish_host: str = "127.0.0.1"
     redfish_username: str = ""
     redfish_password: str = ""
+    redfish_client_timeout: int = DEFAULT_REDFISH_CLIENT_TIMEOUT
+    redfish_client_max_retry: int = DEFAULT_REDFISH_CLIENT_MAX_RETRY
+    redfish_discover_cache_ttl: int = DEFAULT_REDFISH_DISCOVER_CACHE_TTL
 
     @validator("port")
     def validate_port_range(cls, port: int) -> int:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cachetools
 prometheus-client
 pydantic < 2.0
 pyyaml

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,2 +1,3 @@
+cachetools
 pytest
 freezegun

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -16,7 +16,6 @@ from prometheus_hardware_exporter.collector import (
     RedfishCollector,
     SsaCLICollector,
 )
-from prometheus_hardware_exporter.collectors.redfish import RedfishHelper
 
 
 class TestCustomCollector(unittest.TestCase):
@@ -550,7 +549,7 @@ class TestCustomCollector(unittest.TestCase):
     def test_200_redfish_not_installed(self):
         """Test redfish collector when redfish-utilitites is not installed."""
         redfish_collector = RedfishCollector(Mock())
-        redfish_collector.redfish_helper = Mock(spec=RedfishHelper)
+        redfish_collector.redfish_helper = Mock()
         redfish_collector.redfish_helper.discover.return_value = False
         redfish_collector.redfish_helper.get_sensor_data.return_value = []
         payloads = redfish_collector.collect()
@@ -560,7 +559,7 @@ class TestCustomCollector(unittest.TestCase):
     def test_201_redfish_installed_and_okay(self):
         """Test redfish collector when redfish-utilitites is installed."""
         redfish_collector = RedfishCollector(Mock())
-        redfish_collector.redfish_helper = Mock(spec=RedfishHelper)
+        redfish_collector.redfish_helper = Mock()
         redfish_collector.redfish_helper.discover.return_value = False
         redfish_collector.redfish_helper.get_sensor_data.return_value = {
             "1": [

--- a/tests/unit/test_redfish.py
+++ b/tests/unit/test_redfish.py
@@ -5,27 +5,19 @@ from unittest.mock import Mock, patch
 from redfish.rest.v1 import InvalidCredentialsError, SessionCreationError
 
 from prometheus_hardware_exporter.collectors.redfish import RedfishHelper
+from prometheus_hardware_exporter.config import Config
 
 
 class TestRedfishSensors(unittest.TestCase):
     """Test the RedfishSensors class."""
 
     def mock_helper(self):
-        mock_ttl = 10
-        mock_timeout = 3
-        mock_max_retry = 1
-        return RedfishHelper(
-            host="",
-            username="",
-            password="",
-            timeout=mock_timeout,
-            max_retry=mock_max_retry,
-            discover_cache_ttl=mock_ttl,
-        )
+        mock_config = Mock()
+        return RedfishHelper(mock_config)
 
     @patch.object(
         RedfishHelper,
-        "_get_sensor_data",
+        "_retrieve_redfish_sensor_data",
         return_value=[
             {
                 "ChassisName": 1,
@@ -86,7 +78,7 @@ class TestRedfishSensors(unittest.TestCase):
             }
         ],
     )
-    def test_00_get_sensor_data_success(self, mock_get_sensor_data):
+    def test_00_get_sensor_data_success(self, mock_sensor_data):
         helper = self.mock_helper()
         data = helper.get_sensor_data()
         self.assertEqual(
@@ -111,7 +103,7 @@ class TestRedfishSensors(unittest.TestCase):
 
     @patch.object(
         RedfishHelper,
-        "_get_sensor_data",
+        "_retrieve_redfish_sensor_data",
         return_value=[
             {
                 "ChassisName": 1,
@@ -177,7 +169,7 @@ class TestRedfishSensors(unittest.TestCase):
             },
         ],
     )
-    def test_01_get_multiple_chassis_sensor_data_success(self, mock_get_sensor_data):
+    def test_01_get_multiple_chassis_sensor_data_success(self, mock_sensor_data):
         helper = self.mock_helper()
         data = helper.get_sensor_data()
         self.assertEqual(
@@ -202,44 +194,136 @@ class TestRedfishSensors(unittest.TestCase):
             },
         )
 
-    @patch.object(RedfishHelper, "_get_sensor_data", return_value=[])
-    def test_02_get_sensor_data_fail(self, mock_get_sensor_data):
+    @patch.object(RedfishHelper, "_retrieve_redfish_sensor_data", return_value=[])
+    def test_02_get_sensor_data_fail(self, mock_sensor_data):
         helper = self.mock_helper()
         data = helper.get_sensor_data()
         self.assertEqual(data, {})
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_utilities")
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish")
-    def test_03__get_sensor_data_success(self, mock_redfish, mock_redfish_utilities):
-        mock_redfish_utilities.get_sensors.return_value = ["return_data"]
+    def test_03_map_sensor_data_to_chassis(self):
+        mock_data = [
+            {
+                "ChassisName": 1,
+                "Readings": [
+                    {
+                        "Name": "State",
+                        "Reading": "Enabled",
+                        "Units": None,
+                        "State": "Enabled",
+                        "Health": "OK",
+                        "LowerFatal": None,
+                        "LowerCritical": None,
+                        "LowerCaution": None,
+                        "UpperCaution": None,
+                        "UpperCritical": None,
+                        "UpperFatal": None,
+                    },
+                    {
+                        "Name": "HpeServerPowerSupply State",
+                        "Reading": "Enabled",
+                        "Units": None,
+                        "State": "Enabled",
+                        "Health": "OK",
+                        "LowerFatal": None,
+                        "LowerCritical": None,
+                        "LowerCaution": None,
+                        "UpperCaution": None,
+                        "UpperCritical": None,
+                        "UpperFatal": None,
+                    },
+                ],
+            },
+            {
+                "ChassisName": 2,
+                "Readings": [
+                    {
+                        "Name": "HpeServerPowerSupply LineInputVoltage",
+                        "Reading": 208,
+                        "Units": "V",
+                        "State": None,
+                        "Health": None,
+                        "LowerFatal": None,
+                        "LowerCritical": None,
+                        "LowerCaution": None,
+                        "UpperCaution": None,
+                        "UpperCritical": None,
+                        "UpperFatal": None,
+                    },
+                    {
+                        "Name": "HpeServerPowerSupply PowerCapacityWatts",
+                        "Reading": 800,
+                        "Units": "W",
+                        "State": None,
+                        "Health": None,
+                        "LowerFatal": None,
+                        "LowerCritical": None,
+                        "LowerCaution": None,
+                        "UpperCaution": None,
+                        "UpperCritical": None,
+                        "UpperFatal": None,
+                    },
+                ],
+            },
+        ]
 
-        mock_redfish_client = Mock()
-        mock_redfish.redfish_client.return_value = mock_redfish_client
         helper = self.mock_helper()
-        data = helper._get_sensor_data()
+        output = helper._map_sensor_data_to_chassis(mock_data)
+        self.assertEqual(
+            output,
+            {
+                "1": [
+                    {"Sensor": "State", "Reading": "Enabled", "Health": "OK"},
+                    {"Sensor": "HpeServerPowerSupply State", "Reading": "Enabled", "Health": "OK"},
+                ],
+                "2": [
+                    {
+                        "Sensor": "HpeServerPowerSupply LineInputVoltage",
+                        "Reading": "208V",
+                        "Health": "N/A",
+                    },
+                    {
+                        "Sensor": "HpeServerPowerSupply PowerCapacityWatts",
+                        "Reading": "800W",
+                        "Health": "N/A",
+                    },
+                ],
+            },
+        )
+
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_utilities.get_sensors")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    def test_04_retrieve_redfish_sensor_data_success(self, mock_redfish_client, mock_get_sensors):
+        mock_get_sensors.return_value = ["return_data"]
+
+        mock_redfish_obj = Mock()
+        mock_redfish_client.return_value.__enter__.return_value = mock_redfish_obj
+        helper = self.mock_helper()
+        data = helper._retrieve_redfish_sensor_data()
         self.assertEqual(data, ["return_data"])
-        mock_redfish_client.logout.assert_called()
 
     @patch("prometheus_hardware_exporter.collectors.redfish.logger")
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_utilities")
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish")
-    def test_04__get_sensor_data_fail(self, mock_redfish, mock_redfish_utilities, mock_logger):
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    def test_05_retrieve_redfish_sensor_data_fail(
+        self, mock_redfish_client, mock_redfish_utilities, mock_logger
+    ):
         for err in [InvalidCredentialsError(), SessionCreationError()]:
-            mock_redfish_client = Mock()
-            mock_redfish_client.login.side_effect = err
-            mock_redfish.redfish_client.return_value = mock_redfish_client
+            mock_redfish_client.return_value.__enter__.side_effect = err
 
             helper = self.mock_helper()
-            helper._get_sensor_data()
-            mock_redfish_client.logout.assert_called()
-            mock_logger.exception.assert_called_with(mock_redfish_client.login.side_effect)
+            data = helper._retrieve_redfish_sensor_data()
+            mock_logger.exception.assert_called_with(
+                mock_redfish_client.return_value.__enter__.side_effect
+            )
+            self.assertEqual(data, [])
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish")
-    def test_05__get_sensor_data_connection_error(self, mock_redfish):
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    def test_06_retrieve_redfish_sensor_data_connection_error(self, mock_redfish_client):
         """Shouldn't raise error if connection fail."""
-        mock_redfish.redfish_client.side_effect = ConnectionError()
+        mock_redfish_client.return_value.__enter__.side_effect = ConnectionError()
         helper = self.mock_helper()
-        helper._get_sensor_data()
+        data = helper._retrieve_redfish_sensor_data()
+        self.assertEqual(data, [])
 
 
 class TestRedfishServiceStatus(unittest.TestCase):
@@ -249,14 +333,15 @@ class TestRedfishServiceStatus(unittest.TestCase):
         mock_ttl = 10
         mock_timeout = 3
         mock_max_retry = 1
-        return RedfishHelper(
-            host="",
-            username="",
-            password="",
-            timeout=mock_timeout,
-            max_retry=mock_max_retry,
-            discover_cache_ttl=mock_ttl,
+        mock_config = Config(
+            redfish_host="",
+            redfish_username="",
+            redfish_password="",
+            redfish_client_timeout=mock_timeout,
+            redfish_client_max_retry=mock_max_retry,
+            redfish_discover_cache_ttl=mock_ttl,
         )
+        return RedfishHelper(mock_config)
 
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish.discover_ssdp",
@@ -283,14 +368,15 @@ class TestRedfishServiceStatus(unittest.TestCase):
         mock_timeout = 3
         mock_max_retry = 1
         ttl = 1
-        helper = RedfishHelper(
-            host="",
-            username="",
-            password="",
-            timeout=mock_timeout,
-            max_retry=mock_max_retry,
-            discover_cache_ttl=ttl,
+        mock_config = Config(
+            redfish_host="",
+            redfish_username="",
+            redfish_password="",
+            redfish_client_timeout=mock_timeout,
+            redfish_client_max_retry=mock_max_retry,
+            redfish_discover_cache_ttl=ttl,
         )
+        helper = RedfishHelper(mock_config)
 
         output = helper.discover()
         self.assertEqual(output, True)

--- a/tests/unit/test_redfish.py
+++ b/tests/unit/test_redfish.py
@@ -12,13 +12,16 @@ class TestRedfishSensors(unittest.TestCase):
 
     def mock_helper(self):
         mock_ttl = 10
-        return RedfishHelper(mock_ttl)
-
-    def mock_redfish_client_args(self):
-        host, username, password = "", "", ""
         mock_timeout = 3
         mock_max_retry = 1
-        return host, username, password, mock_timeout, mock_max_retry
+        return RedfishHelper(
+            host="",
+            username="",
+            password="",
+            timeout=mock_timeout,
+            max_retry=mock_max_retry,
+            discover_cache_ttl=mock_ttl,
+        )
 
     @patch.object(
         RedfishHelper,
@@ -85,8 +88,7 @@ class TestRedfishSensors(unittest.TestCase):
     )
     def test_00_get_sensor_data_success(self, mock_get_sensor_data):
         helper = self.mock_helper()
-        mock_args = self.mock_redfish_client_args()
-        data = helper.get_sensor_data(*mock_args)
+        data = helper.get_sensor_data()
         self.assertEqual(
             data,
             {
@@ -177,8 +179,7 @@ class TestRedfishSensors(unittest.TestCase):
     )
     def test_01_get_multiple_chassis_sensor_data_success(self, mock_get_sensor_data):
         helper = self.mock_helper()
-        mock_args = self.mock_redfish_client_args()
-        data = helper.get_sensor_data(*mock_args)
+        data = helper.get_sensor_data()
         self.assertEqual(
             data,
             {
@@ -204,8 +205,7 @@ class TestRedfishSensors(unittest.TestCase):
     @patch.object(RedfishHelper, "_get_sensor_data", return_value=[])
     def test_02_get_sensor_data_fail(self, mock_get_sensor_data):
         helper = self.mock_helper()
-        mock_args = self.mock_redfish_client_args()
-        data = helper.get_sensor_data(*mock_args)
+        data = helper.get_sensor_data()
         self.assertEqual(data, {})
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_utilities")
@@ -216,8 +216,7 @@ class TestRedfishSensors(unittest.TestCase):
         mock_redfish_client = Mock()
         mock_redfish.redfish_client.return_value = mock_redfish_client
         helper = self.mock_helper()
-        mock_args = self.mock_redfish_client_args()
-        data = helper._get_sensor_data(*mock_args)
+        data = helper._get_sensor_data()
         self.assertEqual(data, ["return_data"])
         mock_redfish_client.logout.assert_called()
 
@@ -225,14 +224,13 @@ class TestRedfishSensors(unittest.TestCase):
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_utilities")
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish")
     def test_04__get_sensor_data_fail(self, mock_redfish, mock_redfish_utilities, mock_logger):
-        mock_args = self.mock_redfish_client_args()
         for err in [InvalidCredentialsError(), SessionCreationError()]:
             mock_redfish_client = Mock()
             mock_redfish_client.login.side_effect = err
             mock_redfish.redfish_client.return_value = mock_redfish_client
 
             helper = self.mock_helper()
-            helper._get_sensor_data(*mock_args)
+            helper._get_sensor_data()
             mock_redfish_client.logout.assert_called()
             mock_logger.exception.assert_called_with(mock_redfish_client.login.side_effect)
 
@@ -241,8 +239,7 @@ class TestRedfishSensors(unittest.TestCase):
         """Shouldn't raise error if connection fail."""
         mock_redfish.redfish_client.side_effect = ConnectionError()
         helper = self.mock_helper()
-        mock_args = self.mock_redfish_client_args()
-        helper._get_sensor_data(*mock_args)
+        helper._get_sensor_data()
 
 
 class TestRedfishServiceStatus(unittest.TestCase):
@@ -250,7 +247,16 @@ class TestRedfishServiceStatus(unittest.TestCase):
 
     def mock_helper(self):
         mock_ttl = 10
-        return RedfishHelper(mock_ttl)
+        mock_timeout = 3
+        mock_max_retry = 1
+        return RedfishHelper(
+            host="",
+            username="",
+            password="",
+            timeout=mock_timeout,
+            max_retry=mock_max_retry,
+            discover_cache_ttl=mock_ttl,
+        )
 
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish.discover_ssdp",
@@ -274,8 +280,17 @@ class TestRedfishServiceStatus(unittest.TestCase):
         return_value=[1, 2, 3],
     )
     def test_02_discover_cache(self, mock_discover):
+        mock_timeout = 3
+        mock_max_retry = 1
         ttl = 1
-        helper = RedfishHelper(ttl)
+        helper = RedfishHelper(
+            host="",
+            username="",
+            password="",
+            timeout=mock_timeout,
+            max_retry=mock_max_retry,
+            discover_cache_ttl=ttl,
+        )
 
         output = helper.discover()
         self.assertEqual(output, True)


### PR DESCRIPTION
The `redfish.discover_ssdp()` method takes a very long time to query the redfish services. This causes the scrape timeout to be exceeded for Prometheus. In order to solve this, a TTL cache has been added. A logging message has also been added for debugging.

Additionally, the `redfish.redfish_client` call to create a redfish object has been provided with the `timeout` and `max_retry` arguments in order to not have the query take too long in case of incorrect redfish credentials.

Fixes #33, canonical/hardware-observer-operator#55
