### PR TITLE
refactor: Replace redfish discover method.

### DIFF
--- a/prometheus_hardware_exporter/collector.py
+++ b/prometheus_hardware_exporter/collector.py
@@ -946,11 +946,7 @@ class RedfishCollector(BlockingCollector):
         """Load redfish data."""
         payloads: List[Payload] = []
 
-        service_status = self.discover_redfish_services(
-            self.config.redfish_host,
-            self.config.redfish_username,
-            self.config.redfish_password,
-        )
+        service_status = self.discover_redfish_services(self.config.redfish_host)
         payloads.append(Payload(name="redfish_service_available", value=float(service_status)))
         if not service_status:
             return payloads

--- a/prometheus_hardware_exporter/collector.py
+++ b/prometheus_hardware_exporter/collector.py
@@ -863,7 +863,7 @@ class RedfishCollector(BlockingCollector):
         super().__init__(config)
         self.config = config
         self.discover_redfish_services = RedfishHelper.get_cached_discover_method(
-            self.config.redfish_discover_cache_ttl
+            self.config.redfish_discover_cache_ttl,
         )
 
     @property
@@ -946,7 +946,11 @@ class RedfishCollector(BlockingCollector):
         """Load redfish data."""
         payloads: List[Payload] = []
 
-        service_status = self.discover_redfish_services()
+        service_status = self.discover_redfish_services(
+            self.config.redfish_host,
+            self.config.redfish_username,
+            self.config.redfish_password,
+        )
         payloads.append(Payload(name="redfish_service_available", value=float(service_status)))
         if not service_status:
             return payloads

--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -32,10 +32,10 @@ class RedfishHelper:
         """
 
         @ttl_cache(ttl=ttl)
-        def _discover(host: str, username: str, password: str) -> bool:
+        def _discover(host: str) -> bool:
             """Return True if redfish service has been discovered."""
             try:
-                redfish_obj = redfish_client(base_url=host, username=username, password=password)
+                redfish_obj = redfish_client(base_url=host, username="", password="")
                 redfish_obj.login(auth="session")
             except RetriesExhaustedError:
                 # redfish not available

--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -2,10 +2,16 @@
 from logging import getLogger
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-import redfish
 import redfish_utilities
 from cachetools.func import ttl_cache
-from redfish.rest.v1 import HttpClient, RestResponse
+from redfish import redfish_client
+from redfish.rest.v1 import (
+    HttpClient,
+    InvalidCredentialsError,
+    RestResponse,
+    RetriesExhaustedError,
+    SessionCreationError,
+)
 from typing_extensions import Self
 
 from prometheus_hardware_exporter.config import Config
@@ -26,15 +32,27 @@ class RedfishHelper:
         """
 
         @ttl_cache(ttl=ttl)
-        def _discover() -> bool:
-            """Return true if redfish services have been discovered."""
-            logger.info("Discovering redfish services...")
-            services = redfish.discover_ssdp()
-            if len(services) == 0:
-                logger.info("No redfish services discovered")
-                return False
-            logger.debug("Discovered redfish services: %s", services)
-            return True
+        def _discover(host: str, username: str, password: str) -> bool:
+            """Return True if redfish service has been discovered."""
+            try:
+                redfish_obj = redfish_client(base_url=host, username=username, password=password)
+                redfish_obj.login(auth="session")
+            except RetriesExhaustedError:
+                # redfish not available
+                result = False
+            except (SessionCreationError, InvalidCredentialsError):
+                # redfish available, wrong credentials or unable to create a session
+                result = True
+            else:
+                # redfish available, login succeeded
+                result = True
+                redfish_obj.logout()
+
+            if result:
+                logger.debug("Redfish service available.")
+            else:
+                logger.debug("Redfish service not available.")
+            return result
 
         return _discover
 
@@ -49,7 +67,7 @@ class RedfishHelper:
 
     def __enter__(self) -> Self:
         """Login to redfish while entering context manager."""
-        self.redfish_obj = redfish.redfish_client(
+        self.redfish_obj = redfish_client(
             base_url=self.host,
             username=self.username,
             password=self.password,

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -552,7 +552,7 @@ class TestCustomCollector(unittest.TestCase):
         ]:
             assert name in get_payloads
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.RedfishHelper.get_cached_discover_method"
     )
@@ -578,7 +578,7 @@ class TestCustomCollector(unittest.TestCase):
         mock_redfish_client.assert_not_called()
 
     @patch("prometheus_hardware_exporter.collector.logger")
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.RedfishHelper.get_cached_discover_method"
     )
@@ -618,7 +618,7 @@ class TestCustomCollector(unittest.TestCase):
     @patch("prometheus_hardware_exporter.collector.logger")
     @patch("prometheus_hardware_exporter.collectors.redfish.RedfishHelper.__exit__")
     @patch("prometheus_hardware_exporter.collectors.redfish.RedfishHelper.__enter__")
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.RedfishHelper.get_cached_discover_method"
     )

--- a/tests/unit/test_redfish.py
+++ b/tests/unit/test_redfish.py
@@ -16,7 +16,7 @@ from prometheus_hardware_exporter.config import Config
 class TestRedfishMetrics(unittest.TestCase):
     """Test metrics methods in RedfishHelper."""
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     def test_00_redfish_helper_context_manager_success(self, mock_redfish_client):
         mock_redfish_login = Mock()
         mock_redfish_logout = Mock()
@@ -41,7 +41,7 @@ class TestRedfishMetrics(unittest.TestCase):
             mock_redfish_login.assert_called_once_with(auth="session")
         mock_redfish_logout.assert_called_once()
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     def test_01_redfish_helper_context_manager_fail(self, mock_redfish_client):
         mock_config = Config(
             redfish_host="",
@@ -58,7 +58,6 @@ class TestRedfishMetrics(unittest.TestCase):
             RetriesExhaustedError(),
         ]:
             mock_redfish_client.side_effect = err
-            print(type(err))
             with self.assertRaises(
                 (
                     InvalidCredentialsError,
@@ -70,7 +69,7 @@ class TestRedfishMetrics(unittest.TestCase):
                 with RedfishHelper(mock_config):
                     pass
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     def test_02_verify_redfish_call_success(self, mock_redfish_client):
         uri = "/some/test/uri"
         mock_redfish_obj = Mock()
@@ -87,7 +86,7 @@ class TestRedfishMetrics(unittest.TestCase):
         mock_redfish_obj.get.assert_called_with(uri)
 
     @patch("prometheus_hardware_exporter.collectors.redfish.logger")
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     def test_03_verify_redfish_call_fail(self, mock_redfish_client, mock_logger):
         uri = "/some/test/uri"
         mock_redfish_obj = Mock()
@@ -103,7 +102,7 @@ class TestRedfishMetrics(unittest.TestCase):
         mock_logger.debug.assert_called_with("Not able to query from URI: %s.", "/some/test/uri")
         self.assertIsNone(resp_dict)
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch.object(
         RedfishHelper,
         "_retrieve_redfish_sensor_data",
@@ -190,7 +189,7 @@ class TestRedfishMetrics(unittest.TestCase):
             },
         )
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch.object(
         RedfishHelper,
         "_retrieve_redfish_sensor_data",
@@ -286,14 +285,14 @@ class TestRedfishMetrics(unittest.TestCase):
             },
         )
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch.object(RedfishHelper, "_retrieve_redfish_sensor_data", return_value=[])
     def test_06_get_sensor_data_fail(self, mock_sensor_data, mock_redfish_client):
         with RedfishHelper(Mock()) as helper:
             data = helper.get_sensor_data()
         self.assertEqual(data, {})
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     def test_07_map_sensor_data_to_chassis(self, mock_redfish_client):
         mock_data = [
             {
@@ -385,7 +384,7 @@ class TestRedfishMetrics(unittest.TestCase):
         )
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_utilities.get_sensors")
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     def test_08_retrieve_redfish_sensor_data_success(self, mock_redfish_client, mock_get_sensors):
         mock_get_sensors.return_value = ["return_data"]
 
@@ -395,7 +394,7 @@ class TestRedfishMetrics(unittest.TestCase):
             data = helper._retrieve_redfish_sensor_data()
         self.assertEqual(data, ["return_data"])
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.systems.get_system_ids"
     )
@@ -482,7 +481,7 @@ class TestRedfishMetrics(unittest.TestCase):
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s2/Processors")
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s2/Processors/p21")
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.collections.get_collection_ids"  # noqa: E501
     )
@@ -556,7 +555,7 @@ class TestRedfishMetrics(unittest.TestCase):
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Storage/STOR1")
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Storage/STOR2")
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
     )
@@ -596,7 +595,7 @@ class TestRedfishMetrics(unittest.TestCase):
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Chassis/c2/NetworkAdapters")
 
     @patch("prometheus_hardware_exporter.collectors.redfish.logger")
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
     )
@@ -621,7 +620,7 @@ class TestRedfishMetrics(unittest.TestCase):
             "No network adapters could be found on chassis id: %s", "c1"
         )
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
     )
@@ -676,7 +675,7 @@ class TestRedfishMetrics(unittest.TestCase):
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Chassis/c1")
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Chassis/c2")
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.collections.get_collection_ids"  # noqa: E501
     )
@@ -768,7 +767,7 @@ class TestRedfishMetrics(unittest.TestCase):
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Storage/STOR2")
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Storage/STOR2/Drives/d21")
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.systems.get_system_ids"
     )
@@ -837,7 +836,7 @@ class TestRedfishMetrics(unittest.TestCase):
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s2/Memory")
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s2/Memory/dimm2/")
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
     )
@@ -872,7 +871,7 @@ class TestRedfishMetrics(unittest.TestCase):
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Chassis/c1/SmartStorage")
 
     @patch("prometheus_hardware_exporter.collectors.redfish.logger")
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
     )
@@ -900,7 +899,7 @@ class TestRedfishMetrics(unittest.TestCase):
             "Smart Storage URI endpoint not found for chassis ID: %s", "c1"
         )
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.systems.get_system_ids"
     )
@@ -927,7 +926,7 @@ class TestRedfishMetrics(unittest.TestCase):
         self.assertEqual(storage_drive_count, {})
         self.assertEqual(storage_drive_data, {})
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish.redfish_client")
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
     )
@@ -949,47 +948,84 @@ class TestRedfishMetrics(unittest.TestCase):
 class TestRedfishServiceDiscovery(unittest.TestCase):
     """Test redfish service discovery."""
 
-    @patch(
-        "prometheus_hardware_exporter.collectors.redfish.redfish.discover_ssdp",
-        return_value=[1, 2, 3],
-    )
-    def test_00_get_service_status_good(self, mock_discover_ssdp):
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
+    def test_01_redfish_available_login_fail(self, mock_redfish_client):
         test_ttl = 10
-        discover = RedfishHelper.get_cached_discover_method(ttl=test_ttl)
-        ok = discover()
-        self.assertEqual(ok, True)
-        mock_discover_ssdp.assert_called_once()
+        mock_redfish_obj = Mock()
+        mock_redfish_client.return_value = mock_redfish_obj
+        for exc in [SessionCreationError, InvalidCredentialsError]:
+            mock_redfish_obj.login.side_effect = exc
+            discover = RedfishHelper.get_cached_discover_method(ttl=test_ttl)
+            host, username, password = "", "", ""
+            available = discover(host, username, password)
+            self.assertEqual(available, True)
 
-    @patch(
-        "prometheus_hardware_exporter.collectors.redfish.redfish.discover_ssdp", return_value=[]
-    )
-    def test_01_get_service_status_bad(self, mock_discover_ssdp):
+        mock_redfish_client.assert_called()
+        mock_redfish_obj.login.assert_called()
+
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
+    def test_00_redfish_available_login_success(self, mock_redfish_client):
         test_ttl = 10
+        mock_redfish_obj = Mock()
+        mock_redfish_client.return_value = mock_redfish_obj
         discover = RedfishHelper.get_cached_discover_method(ttl=test_ttl)
-        ok = discover()
-        self.assertEqual(ok, False)
-        mock_discover_ssdp.assert_called_once()
+        host, username, password = "mock_host", "mock_user", "mock_pwd"
+        available = discover(host, username, password)
 
-    @patch(
-        "prometheus_hardware_exporter.collectors.redfish.redfish.discover_ssdp",
-        return_value=[1, 2, 3],
-    )
-    def test_02_discover_cache(self, mock_discover_ssdp):
+        self.assertEqual(available, True)
+        mock_redfish_client.assert_called_once_with(
+            base_url="mock_host",
+            username="mock_user",
+            password="mock_pwd",
+        )
+        mock_redfish_obj.login.assert_called_once()
+        mock_redfish_obj.logout.assert_called()
+
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
+    def test_02_redfish_not_available(self, mock_redfish_client):
+        test_ttl = 10
+        mock_redfish_obj = Mock()
+        mock_redfish_client.return_value = mock_redfish_obj
+        mock_redfish_obj.login.side_effect = RetriesExhaustedError()
+        discover = RedfishHelper.get_cached_discover_method(ttl=test_ttl)
+        host, username, password = "mock_host", "mock_user", "mock_pwd"
+        available = discover(host, username, password)
+
+        self.assertEqual(available, False)
+        mock_redfish_client.assert_called_once_with(
+            base_url="mock_host",
+            username="mock_user",
+            password="mock_pwd",
+        )
+        mock_redfish_obj.login.assert_called_once()
+
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
+    def test_03_discover_cache(self, mock_redfish_client):
         test_ttl = 1
-
+        mock_redfish_obj = Mock()
+        mock_redfish_client.return_value = mock_redfish_obj
         discover = RedfishHelper.get_cached_discover_method(ttl=test_ttl)
-        output = discover()
+        host, username, password = "mock_host", "mock_user", "mock_pwd"
+        output = discover(host, username, password)
         self.assertEqual(output, True)
-        mock_discover_ssdp.assert_called()
-        mock_discover_ssdp.reset_mock()
+        mock_redfish_client.assert_called_once_with(
+            base_url="mock_host",
+            username="mock_user",
+            password="mock_pwd",
+        )
+        mock_redfish_client.reset_mock()
 
         # output from cache
-        output = discover()
+        output = discover(host, username, password)
         self.assertEqual(output, True)
-        mock_discover_ssdp.assert_not_called()
+        mock_redfish_client.assert_not_called()
 
         # wait till cache expires
         sleep(test_ttl + 1)
-        output = discover()
+        output = discover(host, username, password)
         self.assertEqual(output, True)
-        mock_discover_ssdp.assert_called()
+        mock_redfish_client.assert_called_with(
+            base_url="mock_host",
+            username="mock_user",
+            password="mock_pwd",
+        )

--- a/tests/unit/test_redfish.py
+++ b/tests/unit/test_redfish.py
@@ -956,8 +956,8 @@ class TestRedfishServiceDiscovery(unittest.TestCase):
         for exc in [SessionCreationError, InvalidCredentialsError]:
             mock_redfish_obj.login.side_effect = exc
             discover = RedfishHelper.get_cached_discover_method(ttl=test_ttl)
-            host, username, password = "", "", ""
-            available = discover(host, username, password)
+            host = ""
+            available = discover(host)
             self.assertEqual(available, True)
 
         mock_redfish_client.assert_called()
@@ -969,14 +969,14 @@ class TestRedfishServiceDiscovery(unittest.TestCase):
         mock_redfish_obj = Mock()
         mock_redfish_client.return_value = mock_redfish_obj
         discover = RedfishHelper.get_cached_discover_method(ttl=test_ttl)
-        host, username, password = "mock_host", "mock_user", "mock_pwd"
-        available = discover(host, username, password)
+        host = "mock_host"
+        available = discover(host)
 
         self.assertEqual(available, True)
         mock_redfish_client.assert_called_once_with(
             base_url="mock_host",
-            username="mock_user",
-            password="mock_pwd",
+            username="",
+            password="",
         )
         mock_redfish_obj.login.assert_called_once()
         mock_redfish_obj.logout.assert_called()
@@ -988,14 +988,14 @@ class TestRedfishServiceDiscovery(unittest.TestCase):
         mock_redfish_client.return_value = mock_redfish_obj
         mock_redfish_obj.login.side_effect = RetriesExhaustedError()
         discover = RedfishHelper.get_cached_discover_method(ttl=test_ttl)
-        host, username, password = "mock_host", "mock_user", "mock_pwd"
-        available = discover(host, username, password)
+        host = "mock_host"
+        available = discover(host)
 
         self.assertEqual(available, False)
         mock_redfish_client.assert_called_once_with(
             base_url="mock_host",
-            username="mock_user",
-            password="mock_pwd",
+            username="",
+            password="",
         )
         mock_redfish_obj.login.assert_called_once()
 
@@ -1005,27 +1005,27 @@ class TestRedfishServiceDiscovery(unittest.TestCase):
         mock_redfish_obj = Mock()
         mock_redfish_client.return_value = mock_redfish_obj
         discover = RedfishHelper.get_cached_discover_method(ttl=test_ttl)
-        host, username, password = "mock_host", "mock_user", "mock_pwd"
-        output = discover(host, username, password)
+        host = "mock_host"
+        output = discover(host)
         self.assertEqual(output, True)
         mock_redfish_client.assert_called_once_with(
             base_url="mock_host",
-            username="mock_user",
-            password="mock_pwd",
+            username="",
+            password="",
         )
         mock_redfish_client.reset_mock()
 
         # output from cache
-        output = discover(host, username, password)
+        output = discover(host)
         self.assertEqual(output, True)
         mock_redfish_client.assert_not_called()
 
         # wait till cache expires
         sleep(test_ttl + 1)
-        output = discover(host, username, password)
+        output = discover(host)
         self.assertEqual(output, True)
         mock_redfish_client.assert_called_with(
             base_url="mock_host",
-            username="mock_user",
-            password="mock_pwd",
+            username="",
+            password="",
         )


### PR DESCRIPTION
* redfish.discover_ssdp method is replaced with a simple login call to the redfish service. If the RetriesExhaustedError exception is raised, we can infer that the redfish service isn't present on the system.
* Caching functionality of redfish discover result is maintained.
* Imports redfish_client method directly instead of importing entire redfish module.
* Modifies unit tests for the new method.

Related: https://github.com/canonical/hardware-observer-operator/issues/61