### PR TITLE
fix(redfish): Make redfish storage name in URI dynamic.

### DIFF
--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -65,6 +65,7 @@ class RedfishHelper:
         self.timeout = config.redfish_client_timeout
         self.max_retry = config.redfish_client_max_retry
         self.redfish_obj: HttpClient
+        self.systems_root_uri: str = "/redfish/v1/Systems/"
 
     def __enter__(self) -> Self:
         """Login to redfish while entering context manager."""
@@ -208,6 +209,18 @@ class RedfishHelper:
         logger.debug("Processor data: %s", processor_data)
         return processor_count, processor_data
 
+    def _storage_root_uri(self, system_id: str, storage_name: str) -> str:
+        """Return formatted URI string for the root storage location.
+
+        storage_root_uri is in the format of "systems_root_uri/system_id/storage_name/"
+
+        eg: For "/redfish/v1/Systems/S1/Storage/",
+          systems_root_uri: "/redfish/v1/Systems"
+          system_id: "S1"
+          storage_name" "Storage"
+        """
+        return self.systems_root_uri + f"{system_id}/{storage_name}/"
+
     def get_storage_controller_data(self) -> Tuple[Dict[str, int], Dict[str, List]]:
         """Return storage controller data and count.
 
@@ -241,11 +254,7 @@ class RedfishHelper:
         storage_controller_data: Dict[str, List] = {}
         # storage controllers on each system
         storage_controller_count: Dict[str, int] = {}
-        systems_root_uri = "/redfish/v1/Systems/"
 
-        # storage_root_uri becomes systems_root_uri/system_id/storage_name
-        # eg: "/redfish/v1/Systems/S1/Storage"
-        storage_root_uri_pattern = systems_root_uri + "{}/{}"
         logger.info("Getting storage controller data...")
 
         try:
@@ -257,23 +266,21 @@ class RedfishHelper:
         for system_id in system_ids:
             storage_controller_count[system_id] = 0
 
-            # finding storage name used in URI
+            # finding storage name used in URI by querying Systems dictionary
             # eg: if storage root URI is /redfish/v1/Systems/S1/Storages
-            # then storage_name becomes "Storages"
-            system_dict = self.redfish_obj.get(systems_root_uri + "/" + system_id).dict
+            # then storage_name is "Storages"
+            system_dict = self.redfish_obj.get(self.systems_root_uri + system_id).dict
             storage_name = system_dict["Storage"]["@odata.id"].split("/")[-1]
 
             # List of storage ids
             storage_ids: List[str] = redfish_utilities.collections.get_collection_ids(
-                self.redfish_obj, storage_root_uri_pattern.format(system_id, storage_name)
+                self.redfish_obj, self._storage_root_uri(system_id, storage_name)
             )
 
             storage_controller_data_in_curr_system = []
             for storage_id in storage_ids:
                 # eg: /redfish/v1/Systems/1/Storage/XYZ123
-                curr_storage_uri = (
-                    storage_root_uri_pattern.format(system_id, storage_name) + "/" + storage_id
-                )
+                curr_storage_uri = self._storage_root_uri(system_id, storage_name) + storage_id
 
                 # list of storage controllers for that storage id
                 storage_controllers_list: List[Dict] = self.redfish_obj.get(curr_storage_uri).dict[
@@ -411,11 +418,6 @@ class RedfishHelper:
         storage_drive_data: Dict[str, List] = {}
         # storage drives on each system
         storage_drive_count: Dict[str, int] = {}
-        systems_root_uri = "/redfish/v1/Systems/"
-
-        # storage_root_uri becomes systems_root_uri/system_id/storage_name
-        # eg: "/redfish/v1/Systems/S1/Storage"
-        storage_root_uri_pattern = systems_root_uri + "{}/{}"
         logger.info("Getting storage drive data...")
 
         try:
@@ -427,22 +429,20 @@ class RedfishHelper:
         for system_id in system_ids:
             storage_drive_count[system_id] = 0
 
-            # finding storage name used in URI
+            # finding storage name used in URI by querying Systems dictionary
             # eg: if storage root URI is /redfish/v1/Systems/S1/Storages
-            # then storage_name becomes "Storages"
-            system_dict = self.redfish_obj.get(systems_root_uri + "/" + system_id).dict
+            # then storage_name is "Storages"
+            system_dict = self.redfish_obj.get(self.systems_root_uri + system_id).dict
             storage_name = system_dict["Storage"]["@odata.id"].split("/")[-1]
 
             storage_ids: List[str] = redfish_utilities.collections.get_collection_ids(
-                self.redfish_obj, storage_root_uri_pattern.format(system_id, storage_name)
+                self.redfish_obj, self._storage_root_uri(system_id, storage_name)
             )
 
             storage_drive_data_in_curr_system: List[Dict] = []
             for storage_id in storage_ids:
                 # eg: /redfish/v1/Systems/1/Storage/XYZ123/
-                curr_storage_uri = (
-                    storage_root_uri_pattern.format(system_id, storage_name) + "/" + storage_id
-                )
+                curr_storage_uri = self._storage_root_uri(system_id, storage_name) + storage_id
 
                 # list of storage drives for that storage id
                 storage_drives_list: List[Dict] = self.redfish_obj.get(curr_storage_uri).dict[

--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -266,9 +266,11 @@ class RedfishHelper:
         for system_id in system_ids:
             storage_controller_count[system_id] = 0
 
-            # finding storage name used in URI by querying Systems dictionary
+            # finding storage name used in URI by querying resource dictionary of system
             # eg: if storage root URI is /redfish/v1/Systems/S1/Storages
             # then storage_name is "Storages"
+            # The storage name in URI can sometimes differ from the standard "Storage"
+            # so we need to query it dynamically to not break the API calls.
             system_dict = self.redfish_obj.get(self.systems_root_uri + system_id).dict
             storage_name = system_dict["Storage"]["@odata.id"].split("/")[-1]
 
@@ -429,9 +431,11 @@ class RedfishHelper:
         for system_id in system_ids:
             storage_drive_count[system_id] = 0
 
-            # finding storage name used in URI by querying Systems dictionary
+            # finding storage name used in URI by querying resource dictionary of system
             # eg: if storage root URI is /redfish/v1/Systems/S1/Storages
             # then storage_name is "Storages"
+            # The storage name in URI can sometimes differ from the standard "Storage"
+            # so we need to query it dynamically to not break the API calls.
             system_dict = self.redfish_obj.get(self.systems_root_uri + system_id).dict
             storage_name = system_dict["Storage"]["@odata.id"].split("/")[-1]
 

--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -273,10 +273,10 @@ class RedfishHelper:
             # then storage_name is "Storages"
             # storage name in URI can sometimes differ from the standard "Storage"
             # so we need to query it dynamically to not break the API calls.
-            system_resources_dict = self.redfish_obj.get(
+            system_resources = self.redfish_obj.get(
                 RedfishHelper.systems_root_uri + system_id
             ).dict
-            storage_name = system_resources_dict["Storage"]["@odata.id"].split("/")[-1]
+            storage_name = system_resources["Storage"]["@odata.id"].split("/")[-1]
 
             # List of storage ids
             storage_ids: List[str] = redfish_utilities.collections.get_collection_ids(
@@ -442,10 +442,10 @@ class RedfishHelper:
             # then storage_name is "Storages"
             # storage name in URI can sometimes differ from the standard "Storage"
             # so we need to query it dynamically to not break the API calls.
-            system_resources_dict = self.redfish_obj.get(
+            system_resources = self.redfish_obj.get(
                 RedfishHelper.systems_root_uri + system_id
             ).dict
-            storage_name = system_resources_dict["Storage"]["@odata.id"].split("/")[-1]
+            storage_name = system_resources["Storage"]["@odata.id"].split("/")[-1]
 
             storage_ids: List[str] = redfish_utilities.collections.get_collection_ids(
                 self.redfish_obj, RedfishHelper._storage_root_uri(system_id, storage_name)

--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -258,11 +258,10 @@ class RedfishHelper:
             storage_controller_count[system_id] = 0
 
             # finding storage name used in URI
-            # eg: if storage_root_uri is /redfish/v1/Systems/S1/Storages
+            # eg: if storage root URI is /redfish/v1/Systems/S1/Storages
             # then storage_name becomes "Storages"
             system_dict = self.redfish_obj.get(systems_root_uri + "/" + system_id).dict
-            storage_root_uri = system_dict["Storage"]["@odata.id"]
-            storage_name = storage_root_uri.split("/")[-1]
+            storage_name = system_dict["Storage"]["@odata.id"].split("/")[-1]
 
             # List of storage ids
             storage_ids: List[str] = redfish_utilities.collections.get_collection_ids(
@@ -429,11 +428,10 @@ class RedfishHelper:
             storage_drive_count[system_id] = 0
 
             # finding storage name used in URI
-            # eg: if storage_root_uri is /redfish/v1/Systems/S1/Storages
+            # eg: if storage root URI is /redfish/v1/Systems/S1/Storages
             # then storage_name becomes "Storages"
             system_dict = self.redfish_obj.get(systems_root_uri + "/" + system_id).dict
-            storage_root_uri = system_dict["Storage"]["@odata.id"]
-            storage_name = storage_root_uri.split("/")[-1]
+            storage_name = system_dict["Storage"]["@odata.id"].split("/")[-1]
 
             storage_ids: List[str] = redfish_utilities.collections.get_collection_ids(
                 self.redfish_obj, storage_root_uri_pattern.format(system_id, storage_name)

--- a/tests/unit/test_redfish.py
+++ b/tests/unit/test_redfish.py
@@ -471,14 +471,6 @@ class TestRedfishMetrics(unittest.TestCase):
             },
         )
 
-        mock_get_system_ids.assert_called_once_with(mock_redfish_obj)
-
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Processors")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Processors/p11")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Processors/p12")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s2/Processors")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s2/Processors/p21")
-
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     def test__storage_root_uri(self, mock_redfish_client):
         """Test RedfishHelper._storage_root_uri method."""
@@ -559,11 +551,6 @@ class TestRedfishMetrics(unittest.TestCase):
                 ],
             },
         )
-
-        mock_get_system_ids.assert_called_once_with(mock_redfish_obj)
-
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Storage/STOR1")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Storage/STOR2")
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
@@ -659,8 +646,6 @@ class TestRedfishMetrics(unittest.TestCase):
             network_adapter_count = helper.get_network_adapter_data()
 
         self.assertEqual(network_adapter_count, {"c1": 2, "c2": 1})
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Chassis/c1/NetworkAdapters")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Chassis/c2/NetworkAdapters")
 
     @patch("prometheus_hardware_exporter.collectors.redfish.logger")
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
@@ -683,7 +668,6 @@ class TestRedfishMetrics(unittest.TestCase):
             network_adapter_count = helper.get_network_adapter_data()
 
         self.assertEqual(network_adapter_count, {})
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Chassis/c1/NetworkAdapters")
         mock_logger.debug.assert_any_call(
             "No network adapters could be found on chassis id: %s", "c1"
         )
@@ -740,8 +724,6 @@ class TestRedfishMetrics(unittest.TestCase):
                 },
             },
         )
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Chassis/c1")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Chassis/c2")
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
@@ -830,14 +812,6 @@ class TestRedfishMetrics(unittest.TestCase):
             },
         )
 
-        mock_get_system_ids.assert_called_once_with(mock_redfish_obj)
-
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Storage/STOR1")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Storage/STOR1/Drives/d11")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Storage/STOR1/Drives/d12")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Storage/STOR2")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Storage/STOR2/Drives/d21")
-
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.systems.get_system_ids"
@@ -900,13 +874,6 @@ class TestRedfishMetrics(unittest.TestCase):
             },
         )
 
-        mock_get_system_ids.assert_called_once_with(mock_redfish_obj)
-
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Memory")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s1/Memory/dimm1/")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s2/Memory")
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s2/Memory/dimm2/")
-
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
@@ -939,7 +906,6 @@ class TestRedfishMetrics(unittest.TestCase):
                 },
             },
         )
-        mock_redfish_obj.get.assert_any_call("/redfish/v1/Chassis/c1/SmartStorage")
 
     @patch("prometheus_hardware_exporter.collectors.redfish.logger")
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")

--- a/tests/unit/test_redfish.py
+++ b/tests/unit/test_redfish.py
@@ -471,15 +471,11 @@ class TestRedfishMetrics(unittest.TestCase):
             },
         )
 
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test__storage_root_uri(self, mock_redfish_client):
+    def test__storage_root_uri(self):
         """Test RedfishHelper._storage_root_uri method."""
-        mock_redfish_client.return_value = Mock()
-
         for storage_name in ["Storage", "Storages", "TestStorage"]:
             expected_uri = f"/redfish/v1/Systems/S1/{storage_name}/"
-            with RedfishHelper(Mock()) as helper:
-                uri = helper._storage_root_uri("S1", storage_name)
+            uri = RedfishHelper._storage_root_uri("S1", storage_name)
             assert uri == expected_uri
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")

--- a/tests/unit/test_redfish.py
+++ b/tests/unit/test_redfish.py
@@ -480,6 +480,15 @@ class TestRedfishMetrics(unittest.TestCase):
         mock_redfish_obj.get.assert_any_call("/redfish/v1/Systems/s2/Processors/p21")
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
+    def test__storage_root_uri(self, mock_redfish_client):
+        """Test RedfishHelper._storage_root_uri method."""
+        mock_redfish_client.return_value = Mock()
+        expected_uri = "/redfish/v1/Systems/S1/TestStorage/"
+        with RedfishHelper(Mock()) as helper:
+            uri = helper._storage_root_uri("S1", "TestStorage")
+        assert uri == expected_uri
+
+    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.collections.get_collection_ids"  # noqa: E501
     )

--- a/tests/unit/test_redfish.py
+++ b/tests/unit/test_redfish.py
@@ -17,7 +17,7 @@ class TestRedfishMetrics(unittest.TestCase):
     """Test metrics methods in RedfishHelper."""
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test_00_redfish_helper_context_manager_success(self, mock_redfish_client):
+    def test_redfish_helper_context_manager_success(self, mock_redfish_client):
         mock_redfish_login = Mock()
         mock_redfish_logout = Mock()
         mock_redfish_client.return_value.login = mock_redfish_login
@@ -42,7 +42,7 @@ class TestRedfishMetrics(unittest.TestCase):
         mock_redfish_logout.assert_called_once()
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test_01_redfish_helper_context_manager_fail(self, mock_redfish_client):
+    def test_redfish_helper_context_manager_fail(self, mock_redfish_client):
         mock_config = Config(
             redfish_host="",
             redfish_username="",
@@ -70,7 +70,7 @@ class TestRedfishMetrics(unittest.TestCase):
                     pass
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test_02_verify_redfish_call_success(self, mock_redfish_client):
+    def test_verify_redfish_call_success(self, mock_redfish_client):
         uri = "/some/test/uri"
         mock_redfish_obj = Mock()
         mock_response = Mock()
@@ -87,7 +87,7 @@ class TestRedfishMetrics(unittest.TestCase):
 
     @patch("prometheus_hardware_exporter.collectors.redfish.logger")
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test_03_verify_redfish_call_fail(self, mock_redfish_client, mock_logger):
+    def test_verify_redfish_call_fail(self, mock_redfish_client, mock_logger):
         uri = "/some/test/uri"
         mock_redfish_obj = Mock()
         mock_response = Mock()
@@ -166,7 +166,7 @@ class TestRedfishMetrics(unittest.TestCase):
             }
         ],
     )
-    def test_04_get_sensor_data_success(self, mock_sensor_data, mock_redfish_client):
+    def test_get_sensor_data_success(self, mock_sensor_data, mock_redfish_client):
         with RedfishHelper(Mock()) as helper:
             data = helper.get_sensor_data()
         self.assertEqual(
@@ -258,9 +258,7 @@ class TestRedfishMetrics(unittest.TestCase):
             },
         ],
     )
-    def test_05_get_multiple_chassis_sensor_data_success(
-        self, mock_sensor_data, mock_redfish_client
-    ):
+    def test_get_multiple_chassis_sensor_data_success(self, mock_sensor_data, mock_redfish_client):
         with RedfishHelper(Mock()) as helper:
             data = helper.get_sensor_data()
         self.assertEqual(
@@ -287,13 +285,13 @@ class TestRedfishMetrics(unittest.TestCase):
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
     @patch.object(RedfishHelper, "_retrieve_redfish_sensor_data", return_value=[])
-    def test_06_get_sensor_data_fail(self, mock_sensor_data, mock_redfish_client):
+    def test_get_sensor_data_fail(self, mock_sensor_data, mock_redfish_client):
         with RedfishHelper(Mock()) as helper:
             data = helper.get_sensor_data()
         self.assertEqual(data, {})
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test_07_map_sensor_data_to_chassis(self, mock_redfish_client):
+    def test_map_sensor_data_to_chassis(self, mock_redfish_client):
         mock_data = [
             {
                 "ChassisName": 1,
@@ -385,7 +383,7 @@ class TestRedfishMetrics(unittest.TestCase):
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_utilities.get_sensors")
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test_08_retrieve_redfish_sensor_data_success(self, mock_redfish_client, mock_get_sensors):
+    def test_retrieve_redfish_sensor_data_success(self, mock_redfish_client, mock_get_sensors):
         mock_get_sensors.return_value = ["return_data"]
 
         mock_redfish_obj = Mock()
@@ -398,7 +396,7 @@ class TestRedfishMetrics(unittest.TestCase):
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.systems.get_system_ids"
     )
-    def test_10_get_processor_data_success(self, mock_get_system_ids, mock_redfish_client):
+    def test_get_processor_data_success(self, mock_get_system_ids, mock_redfish_client):
         mock_redfish_obj = Mock()
         mock_system_ids = ["s1", "s2"]
         mock_get_system_ids.return_value = mock_system_ids
@@ -488,7 +486,7 @@ class TestRedfishMetrics(unittest.TestCase):
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.systems.get_system_ids"
     )
-    def test_11_get_storage_controller_data_success(
+    def test_get_storage_controller_data_success(
         self, mock_get_system_ids, mock_get_collection_ids, mock_redfish_client
     ):
         mock_redfish_obj = Mock()
@@ -565,7 +563,7 @@ class TestRedfishMetrics(unittest.TestCase):
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.systems.get_system_ids"
     )
-    def test_12_non_standard_storage_uri_name(
+    def test_non_standard_storage_uri_name(
         self, mock_get_system_ids, mock_get_collection_ids, mock_redfish_client
     ):
         """Test non-standard name for "Storage" in URI for storage controller and drives.
@@ -620,7 +618,7 @@ class TestRedfishMetrics(unittest.TestCase):
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
     )
-    def test_13_get_network_adapter_data_success(self, mock_get_chassis_ids, mock_redfish_client):
+    def test_get_network_adapter_data_success(self, mock_get_chassis_ids, mock_redfish_client):
         mock_redfish_obj = Mock()
         mock_chassis_ids = ["c1", "c2"]
         mock_get_chassis_ids.return_value = mock_chassis_ids
@@ -660,7 +658,7 @@ class TestRedfishMetrics(unittest.TestCase):
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
     )
-    def test_14_get_network_adapter_data_fail(
+    def test_get_network_adapter_data_fail(
         self, mock_get_chassis_ids, mock_redfish_client, mock_logger
     ):
         mock_redfish_obj = Mock()
@@ -685,7 +683,7 @@ class TestRedfishMetrics(unittest.TestCase):
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
     )
-    def test_15_get_chassis_data_success(self, mock_get_chassis_ids, mock_redfish_client):
+    def test_get_chassis_data_success(self, mock_get_chassis_ids, mock_redfish_client):
         mock_chassis_ids = ["c1", "c2"]
         mock_redfish_obj = Mock()
         mock_get_chassis_ids.return_value = mock_chassis_ids
@@ -743,7 +741,7 @@ class TestRedfishMetrics(unittest.TestCase):
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.systems.get_system_ids"
     )
-    def test_16_get_storage_drive_data_success(
+    def test_get_storage_drive_data_success(
         self, mock_get_system_ids, mock_get_collection_ids, mock_redfish_client
     ):
         mock_redfish_obj = Mock()
@@ -835,7 +833,7 @@ class TestRedfishMetrics(unittest.TestCase):
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.systems.get_system_ids"
     )
-    def test_17_get_memory_dimm_data_success(self, mock_get_system_ids, mock_redfish_client):
+    def test_get_memory_dimm_data_success(self, mock_get_system_ids, mock_redfish_client):
         mock_redfish_obj = Mock()
         mock_system_ids = ["s1", "s2"]
         mock_get_system_ids.return_value = mock_system_ids
@@ -904,7 +902,7 @@ class TestRedfishMetrics(unittest.TestCase):
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
     )
-    def test_18_smart_storage_health_data_success(self, mock_get_chassis_ids, mock_redfish_client):
+    def test_smart_storage_health_data_success(self, mock_get_chassis_ids, mock_redfish_client):
         mock_chassis_ids = ["c1"]
         mock_redfish_obj = Mock()
         mock_get_chassis_ids.return_value = mock_chassis_ids
@@ -939,7 +937,7 @@ class TestRedfishMetrics(unittest.TestCase):
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
     )
-    def test_19_smart_storage_health_data_fail(
+    def test_smart_storage_health_data_fail(
         self, mock_get_chassis_ids, mock_redfish_client, mock_logger
     ):
         mock_chassis_ids = ["c1"]
@@ -967,7 +965,7 @@ class TestRedfishMetrics(unittest.TestCase):
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.systems.get_system_ids"
     )
-    def test_20_get_system_id_fail(self, mock_get_system_ids, mock_redfish_client):
+    def test_get_system_id_fail(self, mock_get_system_ids, mock_redfish_client):
         mock_redfish_obj = Mock()
         mock_get_system_ids.side_effect = redfish_utilities.systems.RedfishSystemNotFoundError
 
@@ -994,7 +992,7 @@ class TestRedfishMetrics(unittest.TestCase):
     @patch(
         "prometheus_hardware_exporter.collectors.redfish.redfish_utilities.inventory.get_chassis_ids"  # noqa: E501
     )
-    def test_21_get_chassis_id_fail(self, mock_get_chassis_ids, mock_redfish_client):
+    def test_get_chassis_id_fail(self, mock_get_chassis_ids, mock_redfish_client):
         mock_redfish_obj = Mock()
         mock_get_chassis_ids.side_effect = redfish_utilities.inventory.RedfishChassisNotFoundError
 
@@ -1013,7 +1011,7 @@ class TestRedfishServiceDiscovery(unittest.TestCase):
     """Test redfish service discovery."""
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test_01_redfish_available_login_fail(self, mock_redfish_client):
+    def test_redfish_available_login_fail(self, mock_redfish_client):
         test_ttl = 10
         mock_redfish_obj = Mock()
         mock_redfish_client.return_value = mock_redfish_obj
@@ -1028,7 +1026,7 @@ class TestRedfishServiceDiscovery(unittest.TestCase):
         mock_redfish_obj.login.assert_called()
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test_00_redfish_available_login_success(self, mock_redfish_client):
+    def test_redfish_available_login_success(self, mock_redfish_client):
         test_ttl = 10
         mock_redfish_obj = Mock()
         mock_redfish_client.return_value = mock_redfish_obj
@@ -1046,7 +1044,7 @@ class TestRedfishServiceDiscovery(unittest.TestCase):
         mock_redfish_obj.logout.assert_called()
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test_02_redfish_not_available(self, mock_redfish_client):
+    def test_redfish_not_available(self, mock_redfish_client):
         test_ttl = 10
         mock_redfish_obj = Mock()
         mock_redfish_client.return_value = mock_redfish_obj
@@ -1064,7 +1062,7 @@ class TestRedfishServiceDiscovery(unittest.TestCase):
         mock_redfish_obj.login.assert_called_once()
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test_03_discover_cache(self, mock_redfish_client):
+    def test_discover_cache(self, mock_redfish_client):
         test_ttl = 1
         mock_redfish_obj = Mock()
         mock_redfish_client.return_value = mock_redfish_obj


### PR DESCRIPTION
The redfish storage name in the URI was initially hardcoded to "Storage". On some servers which did not conform to the schema specification, this name was provided differently, eg: Storages.

This change aims to find the storage uri name dynamically while fetching the storage controller and storage drive data.

Fixes https://github.com/canonical/hardware-observer-operator/issues/91, https://github.com/canonical/hardware-observer-operator/issues/108