### PR TITLE
fix: General err handling for collector

### DIFF
--- a/prometheus_hardware_exporter/core.py
+++ b/prometheus_hardware_exporter/core.py
@@ -91,7 +91,7 @@ class BlockingCollector(Collector):
 
     @property
     def failed_metrics(self) -> Iterable[Metric]:
-        """Defines the metrics return when collect func fail.
+        """Defines the metrics to be returned when collector fails.
 
         Yields:
             metrics: the internal metrics
@@ -99,7 +99,7 @@ class BlockingCollector(Collector):
         name = self.__class__.__name__
         metric = GaugeMetricFamily(
             name=f"{name.lower()}_collector_failed",
-            documentation=f"{name} Collector fail to fetch metrics",
+            documentation=f"{name} Collector failed to fetch metrics",
             labels=["collector"],
         )
         metric.add_metric(

--- a/prometheus_hardware_exporter/core.py
+++ b/prometheus_hardware_exporter/core.py
@@ -99,10 +99,9 @@ class BlockingCollector(Collector):
         name = self.__class__.__name__
         metric = GaugeMetricFamily(
             name=f"{name.lower()}_collector_failed",
-            labels=[],
             documentation=f"{name} Collector fail to fetch metrics",
+            value=1,
         )
-        metric.add_metric(labels=[], value=1)
         yield metric
 
     def init_default_datastore(self, payloads: List[Payload]) -> None:
@@ -117,7 +116,7 @@ class BlockingCollector(Collector):
                     name=payload.name, labels=payload.labels, value=0.0
                 )
 
-    def collect(self) -> Iterable[Metric]:  # pylint: disable=R1710
+    def collect(self) -> Iterable[Metric]:
         """Fetch data and update the internal metrics.
 
         This is a callback method that is used internally within
@@ -149,6 +148,6 @@ class BlockingCollector(Collector):
                 )
                 yield metric
                 self._datastore[payload.uuid] = payload
-        except Exception as e:  # pylint: disable=W0718
-            logger.error(e)
+        except Exception as err:  # pylint: disable=W0718
+            logger.error(err)
             yield from self.failed_metrics

--- a/prometheus_hardware_exporter/core.py
+++ b/prometheus_hardware_exporter/core.py
@@ -100,6 +100,10 @@ class BlockingCollector(Collector):
         metric = GaugeMetricFamily(
             name=f"{name.lower()}_collector_failed",
             documentation=f"{name} Collector fail to fetch metrics",
+            labels=["collector"],
+        )
+        metric.add_metric(
+            labels=[self.__class__.__name__],
             value=1,
         )
         yield metric

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -1237,10 +1237,22 @@ class TestCustomCollector(unittest.TestCase):
         )
 
     def test_1000_collector_fetch_failed(self):
-        for collector_cls, expected_name in [
-            (MegaRAIDCollector, "megaraidcollector_collector_failed"),
-            (RedfishCollector, "redfishcollector_collector_failed"),
-            (IpmiSensorsCollector, "ipmisensorscollector_collector_failed"),
+        for collector_cls, expected_name, expected_labels in [
+            (
+                MegaRAIDCollector,
+                "megaraidcollector_collector_failed",
+                {"collector": "MegaRAIDCollector"},
+            ),
+            (
+                RedfishCollector,
+                "redfishcollector_collector_failed",
+                {"collector": "RedfishCollector"},
+            ),
+            (
+                IpmiSensorsCollector,
+                "ipmisensorscollector_collector_failed",
+                {"collector": "IpmiSensorsCollector"},
+            ),
         ]:
             collector = collector_cls(Mock())
             collector.fetch = Mock()
@@ -1249,4 +1261,5 @@ class TestCustomCollector(unittest.TestCase):
             payloads = list(payloads)
             self.assertEqual(len(payloads), 1)
             self.assertEqual(payloads[0].name, expected_name)
-            assert payloads[0].samples[0].value == 1.0
+            self.assertEqual(payloads[0].samples[0].value, 1.0)
+            self.assertEqual(payloads[0].samples[0].labels, expected_labels)

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -1235,3 +1235,18 @@ class TestCustomCollector(unittest.TestCase):
                 )
             ],
         )
+
+    def test_1000_collector_fetch_failed(self):
+        for collector_cls, expected_name in [
+            (MegaRAIDCollector, "megaraidcollector_collector_failed"),
+            (RedfishCollector, "redfishcollector_collector_failed"),
+            (IpmiSensorsCollector, "ipmisensorscollector_collector_failed"),
+        ]:
+            collector = collector_cls(Mock())
+            collector.fetch = Mock()
+            collector.fetch.side_effect = Exception("Unknow error")
+            payloads = collector.collect()
+            payloads = list(payloads)
+            self.assertEqual(len(payloads), 1)
+            self.assertEqual(payloads[0].name, expected_name)
+            assert payloads[0].samples[0].value == 1.0

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -1256,7 +1256,7 @@ class TestCustomCollector(unittest.TestCase):
         ]:
             collector = collector_cls(Mock())
             collector.fetch = Mock()
-            collector.fetch.side_effect = Exception("Unknow error")
+            collector.fetch.side_effect = Exception("Unknown error")
             payloads = collector.collect()
             payloads = list(payloads)
             self.assertEqual(len(payloads), 1)


### PR DESCRIPTION
The error handler will try to output the failed metrics and make sure the single collector's bug won't affect other collectors.

---

Review together with: https://github.com/canonical/hardware-observer-operator/pull/117