### PR TITLE
Recreate sdr cache if invalid

### DIFF
--- a/prometheus_hardware_exporter/collectors/ipmi_sel.py
+++ b/prometheus_hardware_exporter/collectors/ipmi_sel.py
@@ -23,6 +23,9 @@ class IpmiSel(Command):
         Returns:
             sel_entries: a list of dictionaries containing sel_sentries, or []
         """
+        # --sdr-cache-recreate is required to automatically recreate the SDR cache in case it is
+        # out of date or invalid. Without this, the service will stop getting ipmi-sel data if the
+        # cache is out of date.
         result = self(
             "--sdr-cache-recreate --output-event-state --interpret-oem-data --entity-sensor-names"
         )

--- a/prometheus_hardware_exporter/collectors/ipmi_sel.py
+++ b/prometheus_hardware_exporter/collectors/ipmi_sel.py
@@ -23,7 +23,9 @@ class IpmiSel(Command):
         Returns:
             sel_entries: a list of dictionaries containing sel_sentries, or []
         """
-        result = self("--output-event-state --interpret-oem-data --entity-sensor-names")
+        result = self(
+            "--sdr-cache-recreate --output-event-state --interpret-oem-data --entity-sensor-names"
+        )
         if result.error:
             logger.error(result.error)
             return None

--- a/prometheus_hardware_exporter/collectors/ipmimonitoring.py
+++ b/prometheus_hardware_exporter/collectors/ipmimonitoring.py
@@ -20,6 +20,9 @@ class IpmiMonitoring(Command):
         Returns:
             sensor_data: a list of dictionaries containing sensor data, or []
         """
+        # --sdr-cache-recreate is required to automatically recreate the SDR cache in case it is
+        # out of date or invalid. Without this, the service will stop getting sensor data if the
+        # cache is out of date.
         result = self("--sdr-cache-recreate")
         if result.error:
             logger.error(result.error)

--- a/prometheus_hardware_exporter/collectors/ipmimonitoring.py
+++ b/prometheus_hardware_exporter/collectors/ipmimonitoring.py
@@ -20,7 +20,7 @@ class IpmiMonitoring(Command):
         Returns:
             sensor_data: a list of dictionaries containing sensor data, or []
         """
-        result = self()
+        result = self("--sdr-cache-recreate")
         if result.error:
             logger.error(result.error)
             return []

--- a/tests/unit/test_ipmi_sel.py
+++ b/tests/unit/test_ipmi_sel.py
@@ -51,6 +51,9 @@ class TestIpmiSel(unittest.TestCase):
             ipmi_sel = IpmiSel(config)
             payloads = ipmi_sel.get_sel_entries(24 * 60 * 60)
             expected_sel_entries = SAMPLE_SEL_ENTRIES
+            mock_call.assert_called_with(
+                "--sdr-cache-recreate --output-event-state --interpret-oem-data --entity-sensor-names"  # noqa: E501
+            )
             self.assertEqual(payloads, expected_sel_entries)
 
     @patch.object(Command, "__call__")
@@ -59,6 +62,9 @@ class TestIpmiSel(unittest.TestCase):
         config = Config()
         ipmi_sel = IpmiSel(config)
         payloads = ipmi_sel.get_sel_entries(300)
+        mock_call.assert_called_with(
+            "--sdr-cache-recreate --output-event-state --interpret-oem-data --entity-sensor-names"
+        )
         self.assertEqual(payloads, [])
 
     @patch.object(Command, "__call__")
@@ -67,4 +73,7 @@ class TestIpmiSel(unittest.TestCase):
         config = Config()
         ipmi_sel = IpmiSel(config)
         payloads = ipmi_sel.get_sel_entries(300)
+        mock_call.assert_called_with(
+            "--sdr-cache-recreate --output-event-state --interpret-oem-data --entity-sensor-names"
+        )
         self.assertEqual(payloads, None)

--- a/tests/unit/test_ipmimonitoring.py
+++ b/tests/unit/test_ipmimonitoring.py
@@ -48,6 +48,7 @@ class TestIpmiMonitoring(unittest.TestCase):
             ipmimonitoring = IpmiMonitoring(config)
             payloads = ipmimonitoring.get_sensor_data()
             expected_sensor_entries = SAMPLE_SENSOR_ENTRIES
+            mock_call.assert_called_with("--sdr-cache-recreate")
             self.assertEqual(payloads, expected_sensor_entries)
 
     @patch.object(Command, "__call__")
@@ -56,4 +57,5 @@ class TestIpmiMonitoring(unittest.TestCase):
         config = Config()
         ipmimonitoring = IpmiMonitoring(config)
         payloads = ipmimonitoring.get_sensor_data()
+        mock_call.assert_called_with("--sdr-cache-recreate")
         self.assertEqual(payloads, [])


### PR DESCRIPTION
This recreates the ipmi sdr cache if it's out of date or invalid.
If the sdr cache is working, nothing changes.

Closes #40 