### PR TITLE
Update the out-of-date readme file

### DIFF
--- a/README-SNAP.md
+++ b/README-SNAP.md
@@ -10,8 +10,8 @@ You need `snapcraft` to build the snap:
 sudo snap install snapcraft --classic
 ```
 
-Snapcraft also requires backend to create isolated build environment, you can
-choose the following two backends:
+Snapcraft also requires backend to create isolated build environment. You can
+choose either of the following two backends for snapcraft:
 
 - [LXD](https://linuxcontainers.org/lxd/introduction/), which creates container
   image build instances. It can be used inside virtual machines.

--- a/README-SNAP.md
+++ b/README-SNAP.md
@@ -1,4 +1,4 @@
-## Prometheus Hardware Exporter Snap
+# Prometheus Hardware Exporter Snap
 
 **Work In Progress**: the snap is only ready for local testing.
 

--- a/README-SNAP.md
+++ b/README-SNAP.md
@@ -1,0 +1,63 @@
+## Prometheus Hardware Exporter Snap
+
+**Work In Progress**: the snap is only ready for local testing.
+
+## Local Build and Testing
+
+You need `snapcraft` to build the snap:
+
+```shell
+sudo snap install snapcraft --classic
+```
+
+Snapcraft also requires backend to create isolated build environment, you can
+choose the following two backends:
+
+- [LXD](https://linuxcontainers.org/lxd/introduction/), which creates container
+  image build instances. It can be used inside virtual machines.
+- [Multipass](https://multipass.run/), which creates virtual machine build
+  instances. It cannot be reliably used on platforms that do not support nested
+  virtualization. For instance, Multipass will most likely not run inside a
+  virtual machine itself.
+
+To build the snap:
+
+```shell
+make build
+```
+
+To try the snap that was built, you can install it locally:
+
+```shell
+sudo snap install --devmode ./$(grep -E "^name:" snap/snapcraft.yaml | awk '{print $2}').snap
+```
+
+Start the exporter:
+
+```shell
+sudo snap start prometheus-hardware-exporter  # by default it listen on port 10000
+```
+
+When you're done testing, you can remove the snap:
+
+```shell
+sudo snap remove prometheus-hardware-exporter
+```
+
+## Snap Configuration
+
+The install hook (`./snap/hooks/install`) will generate a default configuration
+for the exporter. By default, the exporter is started at port 10000 with a
+logging level of INFO.
+
+You can change the default configuration by editing
+
+```shell
+/var/snap/prometheus-hardware-exporter/current/config.yaml
+```
+
+and then restart the snap by
+
+```shell
+sudo snap restart prometheus-hardware-exporter
+```

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ management controllers) using IPMI (Intelligent Platform Management Interface)
 and Redfish protocol. It also exports and various SAS (Serial Attached SCSI) and
 RAID (redundant array of inexpensive disks) controllers.
 
-Prometheus Hardware Exporter is recommended for [Juju](https://juju.is/) users,
-you can deploy Prometheus Hardware Exporter using the Hardware Observer charm.
-You can learn more about Hardware Observer on
+Prometheus Hardware Exporter is recommended for [Juju](https://juju.is/) users.
+You can deploy Prometheus Hardware Exporter using the Hardware Observer charm.
+For more information, you can read the documentation about Hardware Observer on
 [Charmhub](https://charmhub.io/hardware-observer).
 
 **Note**: this exporter does not bundle the required third party or proprietary
@@ -50,8 +50,8 @@ To start the exporter at port `10000` and enable the ipmi sensor collector, run:
 
 Note that all the exporters are disabled by default as you will need to install
 the appropriate third party or proprietary software to run the collectors.  You
-can check out [Resources](200~https://charmhub.io/hardware-observer/resources/)
-to find out more information about the third party software.
+can check out [Resources](https://charmhub.io/hardware-observer/resources/) to
+find out more information about the third party software.
 
 ## Supported Metrics
 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,20 @@ management controllers) using IPMI (Intelligent Platform Management Interface)
 and Redfish protocol. It also exports and various SAS (Serial Attached SCSI) and
 RAID (redundant array of inexpensive disks) controllers.
 
-Note that the exporter does not bundle the required third party or proprietary
-software. If you would like to use this exporter you will need to install them
-by yourself. Therefore, Prometheus Hardware Exporter is recommended for
-[Juju](https://juju.is/) users, you can learn more about Hardware Observer on
+Prometheus Hardware Exporter is recommended for [Juju](https://juju.is/) users,
+you can deploy Prometheus Hardware Exporter using the Hardware Observer charm.
+You can learn more about Hardware Observer on
 [Charmhub](https://charmhub.io/hardware-observer).
+
+**Note**: this exporter does not bundle the required third party or proprietary
+software. If you would like to use this exporter, you will need to install them
+by yourself.
 
 ## Installation
 
-This package is not published in anywhere yet. For now, you can should install
-this application locally (or via a virtual environment). To install it on a
-virtual environment, you can run:
+This package is not published anywhere as of now. Currently, it can be installed
+locally or on a virtual environment. To install it on a virtual environment,
+run:
 
 ```shell
 # Install virtualvenv and source it
@@ -23,12 +26,12 @@ pip3 install virtualenv
 python3 -m venv venv
 source venv/bin/activate
 
-# Install the prometheus-hardware-exporter package; the "(venv)" means you are
-# under the virtual environment
+# Install the prometheus-hardware-exporter package; the "(venv)" prefix on the
+# shell prompt indicates that the virtual environment is active.
 (venv) pip3 install .
 ```
 
-To verify you have install the package, you can run:
+To verify that the package has been installed successfully, run:
 
 ```shell
 (venv) prometheus-hardware-exporter -h
@@ -39,8 +42,7 @@ the virtual environment.
 
 ## Usages
 
-To run the exporter at port `10000` and enable the ipmi sensor collector, you
-can run:
+To start the exporter at port `10000` and enable the ipmi sensor collector, run:
 
 ```shell
 (venv) prometheus-hardware-exporter -p 10000 --collector.ipmi_sensor

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ documentation](https://charmhub.io/hardware-observer/docs/metrics-and-alerts-com
 
 This is still work in progress, and only support local testing. For more
 information on building and running the snap locally, please refer to
-[README-SNAP.md](https://github.com/canonical/prometheus-hardware-exporter/blob/main/README-SNAP.md)
+[README-SNAP.md](README-SNAP.md)

--- a/README.md
+++ b/README.md
@@ -1,65 +1,63 @@
-# Prometheus Exporter Snap for Hardware Observer charm
+# Prometheus Hardware Exporter
 
+Prometheus Hardware Exporter exports Prometheus metrics from BMCs (Baseboard
+management controllers) using IPMI (Intelligent Platform Management Interface)
+and Redfish protocol. It also exports and various SAS (Serial Attached SCSI) and
+RAID (redundant array of inexpensive disks) controllers.
 
-You can learn more about Hardware Observer on [Charmhub](https://charmhub.io/hardware-observer).
-## Getting Started
+Note that the exporter does not bundle the required third party or proprietary
+software. If you would like to use this exporter you will need to install them
+by yourself. Therefore, Prometheus Hardware Exporter is recommended for
+[Juju](https://juju.is/) users, you can learn more about Hardware Observer on
+[Charmhub](https://charmhub.io/hardware-observer).
 
-Install the snap from snap store:
+## Installation
 
-```bash
-$ sudo snap install prometheus-hardware-exporter --classic
+This package is not published in anywhere yet. For now, you can should install
+this application locally (or via a virtual environment). To install it on a
+virtual environment, you can run:
+
+```shell
+# Install virtualvenv and source it
+pip3 install virtualenv
+python3 -m venv venv
+source venv/bin/activate
+
+# Install the prometheus-hardware-exporter package; the "(venv)" means you are
+# under the virtual environment
+(venv) pip3 install .
 ```
 
-Start the exporter:
+To verify you have install the package, you can run:
 
-```bash
-$ sudo snap start prometheus-hardware-exporter
+```shell
+(venv) prometheus-hardware-exporter -h
 ```
 
-## Snap Configuration
+If you see the help message, then `prometheus-hardware-exporter` is installed on
+the virtual environment.
 
-The install hook (`./snap/hooks/install`) will generate a default configuration
-for the exporter. By default, the exporter is started at port 10000 with a
-logging level of INFO.
+## Usages
 
-You can change the default configuration by editing
+To run the exporter at port `10000` and enable the ipmi sensor collector, you
+can run:
 
-```bash
-$ /var/snap/prometheus-hardware-exporter/current/config.yaml
+```shell
+(venv) prometheus-hardware-exporter -p 10000 --collector.ipmi_sensor
 ```
 
-and then restart the snap by
+Note that all the exporters are disabled by default as you will need to install
+the appropriate third party or proprietary software to run the collectors.  You
+can check out [Resources](200~https://charmhub.io/hardware-observer/resources/)
+to find out more information about the third party software.
 
-```bash
-$ sudo snap restart prometheus-hardware-exporter
-```
+## Supported Metrics
 
-## Local Build and Testing
+You can learn more about the metrics from [Hardware Observer
+documentation](https://charmhub.io/hardware-observer/docs/metrics-and-alerts-common).
 
-You need `snapcraft` to build the snap:
+## Snap support
 
-```bash
-$ sudo snap install snapcraft --classic
-```
-
-Snapcraft also requires backend to create isolated build environment, you can
-choose the following two backends:
-
-- [LXD](https://linuxcontainers.org/lxd/introduction/), which creates container
-  image build instances. It can be used inside virtual machines.
-- [Multipass](https://multipass.run/), which creates virtual machine build
-  instances. It cannot be reliably used on platforms that do not support nested
-  virtualization. For instance, Multipass will most likely not run inside a
-  virtual machine itself.
-
-To build the snap:
-
-```bash
-$ make build
-```
-
-To try the snap that was built, you can install it locally:
-
-```bash
-$ sudo snap install --devmode ./$(grep -E "^name:" snap/snapcraft.yaml | awk '{print $2}').snap
-```
+This is still work in progress, and only support local testing. For more
+information on building and running the snap locally, please refer to
+[README-SNAP.md](https://github.com/canonical/prometheus-hardware-exporter/blob/main/README-SNAP.md)

--- a/prometheus_hardware_exporter/__main__.py
+++ b/prometheus_hardware_exporter/__main__.py
@@ -1,4 +1,4 @@
-"""Package entrypoint."""
+"""Collect and export metrics for various hardware component."""
 
 import argparse
 import logging

--- a/prometheus_hardware_exporter/collector.py
+++ b/prometheus_hardware_exporter/collector.py
@@ -331,7 +331,7 @@ class IpmiDcmiCollector(BlockingCollector):
     """Collector for ipmi dcmi metrics."""
 
     def __init__(self, config: Config) -> None:
-        """Initialze the collector."""
+        """Initialize the collector."""
         self.ipmi_dcmi = IpmiDcmi(config)
         self.ipmi_tool = IpmiTool(config)
         self.dmidecode = Dmidecode(config)

--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -335,7 +335,7 @@ class RedfishHelper:
                     health = data.get("Status", {}).get("Health", "NA")
                     if controller_id == "" or not state:  # health is not required
                         logger.warning(
-                            "No relavent data found in storage controller data: %s", data
+                            "No relevant data found in storage controller data: %s", data
                         )
                         continue
                     storage_controller_count[system_id] += 1

--- a/prometheus_hardware_exporter/collectors/sasircu.py
+++ b/prometheus_hardware_exporter/collectors/sasircu.py
@@ -88,7 +88,7 @@ class Sasircu(Command):
         return data
 
     def _get_controller(self, text: str) -> Dict[str, str]:
-        """Return controller information from the contoller section text.
+        """Return controller information from the controller section text.
 
         Returns:
             Controller information

--- a/prometheus_hardware_exporter/core.py
+++ b/prometheus_hardware_exporter/core.py
@@ -132,7 +132,7 @@ class BlockingCollector(Collector):
         Yields:
             metrics: the internal metrics
         """
-        # The general exception hanlder will try to make sure the single
+        # The general exception handler will try to make sure the single
         # collector's bug will only change the metrics output to failed_metrics
         # and also make sure other collectors are still working.
         try:

--- a/prometheus_hardware_exporter/exporter.py
+++ b/prometheus_hardware_exporter/exporter.py
@@ -20,7 +20,7 @@ class ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
 
 
 class SlientRequestHandler(WSGIRequestHandler):
-    """A Slient Request handler."""
+    """A Silent Request handler."""
 
     def log_message(self, format: str, *args: Any) -> None:  # pylint: disable=W0622
         """Log nothing."""

--- a/prometheus_hardware_exporter/exporter.py
+++ b/prometheus_hardware_exporter/exporter.py
@@ -19,7 +19,7 @@ class ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
     daemon_threads = True
 
 
-class SlientRequestHandler(WSGIRequestHandler):
+class SilentRequestHandler(WSGIRequestHandler):
     """A Silent Request handler."""
 
     def log_message(self, format: str, *args: Any) -> None:  # pylint: disable=W0622
@@ -51,7 +51,7 @@ class Exporter:
             self.port,
             self.app,
             server_class=ThreadingWSGIServer,
-            handler_class=SlientRequestHandler,
+            handler_class=SilentRequestHandler,
         )
         logger.info("Started prometheus hardware exporter at %s:%s.", self.addr, self.port)
         thread = threading.Thread(target=httpd.serve_forever)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ configs = {
     "description": "exports hardware related metrics",
     "use_scm_version": True,
     "setup_requires": ["setuptools_scm", "pyyaml"],
-    "author": "Canonical BootStack DevOps Centres",
+    "author": "Canonical Solution Engineering",
     "packages": ["prometheus_hardware_exporter", "prometheus_hardware_exporter.collectors"],
     "url": "https://github.com/canonical/prometheus-hardware-exporter",
     "entry_points": {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ summary: collects hardware related information and exports them as metrics
 description: |
   The prometheus-hardware-exporter is a snap for collecting hardware related
   information from the host machine, and export them as prometheus metrics.
-grade: stable
+grade: devel
 confinement: classic
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,12 +1,10 @@
 name: prometheus-hardware-exporter
 base: core22
 adopt-info: prometheus-hardware-exporter
-summary: collects backup results and exports them as metrics
+summary: collects hardware related information and exports them as metrics
 description: |
-  The prometheus-hardware-exporter is a snap for collecting backup
-  results from charm-hardware, and export those results as prometheus
-  metrics. The metrics are expected to be used with prometheus.
-
+  The prometheus-hardware-exporter is a snap for collecting hardware related
+  information from the host machine, and export them as prometheus metrics.
 grade: stable
 confinement: classic
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
   The prometheus-hardware-exporter is a snap for collecting hardware related
   information from the host machine, and export them as prometheus metrics.
 grade: devel
-confinement: classic
+confinement: strict
 
 apps:
   prometheus-hardware-exporter:

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ basepython = python3
 setenv = PYTHONPATH={toxinidir}
 
 [testenv:dev-environment]
-envdir = {toxinidir}/.venv
 deps =
     pre-commit
     {[testenv:lint]deps}
@@ -22,7 +21,6 @@ commands =
     pre-commit install
 
 [testenv:pre-commit]
-envdir = {[testenv:dev-environment]envdir}
 deps = {[testenv:dev-environment]deps}  # ensure that dev-environment is installed
 commands = pre-commit run --all-files
 
@@ -48,7 +46,6 @@ deps =
     {[testenv:func]deps}
 
 [testenv:reformat]
-envdir = {toxworkdir}/lint
 deps = {[testenv:lint]deps}
 commands =
     black .


### PR DESCRIPTION
- Remove `envdir` from `tox.ini` as it was never intended to be used like that
- Update existing `README.md`
- Create a `README-SNAP.md` for snap.
- Fixed broken snap build
- Fixed typo in class name