### PR TITLE
Fix regression from #71.

### DIFF
--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -331,8 +331,10 @@ class RedfishHelper:
                 for data in storage_controllers_list:
                     # "Id" is what we expect if the key being used is Controllers
                     controller_id = data.get("MemberId") or data.get("Id")
-                    state = data.get("Status", {}).get("State")  # when is falsy set to None
-                    health = data.get("Status", {}).get("Health") or "NA"  # when is falsy set NA
+                    state = data.get("Status", {}).get("State")  # when it's falsy set to None
+                    health = (
+                        data.get("Status", {}).get("Health") or "NA"
+                    )  # when it's falsy set to NA
                     if not controller_id or not state:  # health is not required
                         logger.warning(
                             "No relevant data found in storage controller data: %s", data

--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -330,10 +330,10 @@ class RedfishHelper:
                 # picking out the required data from each storage controller in the list
                 for data in storage_controllers_list:
                     # "Id" is what we expect if the key being used is Controllers
-                    controller_id = data.get("MemberId", "") or data.get("Id", "")
-                    state = data.get("Status", {}).get("State", None)
-                    health = data.get("Status", {}).get("Health", "NA")
-                    if controller_id == "" or not state:  # health is not required
+                    controller_id = data.get("MemberId") or data.get("Id")
+                    state = data.get("Status", {}).get("State")  # when is falsy set to None
+                    health = data.get("Status", {}).get("Health") or "NA"  # when is falsy set NA
+                    if not controller_id or not state:  # health is not required
                         logger.warning(
                             "No relevant data found in storage controller data: %s", data
                         )

--- a/tests/unit/test_redfish.py
+++ b/tests/unit/test_redfish.py
@@ -435,7 +435,7 @@ class TestRedfishMetrics(unittest.TestCase):
         self, storage_name, mock_get_system_ids, mock_get_collection_ids
     ):
         mock_system_ids = ["s1"]
-        mock_storage_ids = ["STOR1", "STOR2"]
+        mock_storage_ids = ["STOR1", "STOR2", "STOR3"]
 
         mock_get_system_ids.return_value = mock_system_ids
         mock_get_collection_ids.return_value = mock_storage_ids
@@ -461,6 +461,15 @@ class TestRedfishMetrics(unittest.TestCase):
                         }
                     ]
                 }
+            elif f"{storage_root}/STOR3" in uri:  # missing Health case
+                response.dict = {
+                    "StorageControllers": [
+                        {
+                            "MemberId": "sc2",
+                            "Status": {"State": "Enabled"},
+                        }
+                    ]
+                }
             # response for GET request to /redfish/v1/Systems/<sys_id>/
             elif "Systems" in uri:
                 response.dict = {
@@ -478,7 +487,7 @@ class TestRedfishMetrics(unittest.TestCase):
                 storage_controller_data,
             ) = redfish_helper.get_storage_controller_data()
 
-        self.assertEqual(storage_controller_count, {"s1": 2})
+        self.assertEqual(storage_controller_count, {"s1": 3})
         self.assertEqual(
             storage_controller_data,
             {
@@ -493,6 +502,12 @@ class TestRedfishMetrics(unittest.TestCase):
                         "storage_id": "STOR2",
                         "controller_id": "sc1",
                         "health": "OK",
+                        "state": "Enabled",
+                    },
+                    {
+                        "storage_id": "STOR3",
+                        "controller_id": "sc2",
+                        "health": "NA",
                         "state": "Enabled",
                     },
                 ],

--- a/tests/unit/test_redfish.py
+++ b/tests/unit/test_redfish.py
@@ -435,7 +435,7 @@ class TestRedfishMetrics(unittest.TestCase):
         self, storage_name, mock_get_system_ids, mock_get_collection_ids
     ):
         mock_system_ids = ["s1"]
-        mock_storage_ids = ["STOR1", "STOR2", "STOR3"]
+        mock_storage_ids = ["STOR1", "STOR2", "STOR3", "STOR4"]
 
         mock_get_system_ids.return_value = mock_system_ids
         mock_get_collection_ids.return_value = mock_storage_ids
@@ -470,6 +470,15 @@ class TestRedfishMetrics(unittest.TestCase):
                         }
                     ]
                 }
+            elif f"{storage_root}/STOR4" in uri:  # Health is None
+                response.dict = {
+                    "StorageControllers": [
+                        {
+                            "MemberId": "sc3",
+                            "Status": {"Health": None, "State": "Enabled"},
+                        }
+                    ]
+                }
             # response for GET request to /redfish/v1/Systems/<sys_id>/
             elif "Systems" in uri:
                 response.dict = {
@@ -487,7 +496,7 @@ class TestRedfishMetrics(unittest.TestCase):
                 storage_controller_data,
             ) = redfish_helper.get_storage_controller_data()
 
-        self.assertEqual(storage_controller_count, {"s1": 3})
+        self.assertEqual(storage_controller_count, {"s1": 4})
         self.assertEqual(
             storage_controller_data,
             {
@@ -507,6 +516,12 @@ class TestRedfishMetrics(unittest.TestCase):
                     {
                         "storage_id": "STOR3",
                         "controller_id": "sc2",
+                        "health": "NA",
+                        "state": "Enabled",
+                    },
+                    {
+                        "storage_id": "STOR4",
+                        "controller_id": "sc3",
                         "health": "NA",
                         "state": "Enabled",
                     },


### PR DESCRIPTION
Set the "Health" key to a string of "NA" when it's falsy (e.g. `None`, "").

Note: 

```
d.get("key") or "NA"  # return NA if d = {"key": <falsy-value>}
d.get("key", "NA")     # return None if d = {"key": <falsy-value>}
```

If "Health" is `None`, it can cause the following error:

```
AttributeError: ("'NoneType' object has no attribute 'replace'", Metric(redfish_storage_controller, Storage Controller information obtained from redfish., info, , [Sample(name='redfish_storage_controller_info', labels={'system_id': 'System.Embedded.1', 'storage_id': 'AHCI.Embedded.1-1', 'controller_id': '0', 'health': None, 'state': 'Enabled'}, value=1, timestamp=None, exemplar=None)]))
```
