### PR TITLE
Ignore if redfish fails to logout

### DIFF
--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -100,9 +100,7 @@ class RedfishHelper:
             self.redfish_obj.logout()
             logger.debug("(service) Logged out from redfish service ...")
         except BadRequestError as err:
-            logger.error("Failed to logout redfish: %s", str(err))
-            if "code: 401" not in str(err):
-                raise
+            logger.warning("Failed to logout redfish: %s", str(err))
 
     def get_sensor_data(self) -> Dict[str, List]:
         """Get sensor data.

--- a/tests/unit/test_redfish.py
+++ b/tests/unit/test_redfish.py
@@ -1098,8 +1098,8 @@ class TestRedfishServiceDiscovery(unittest.TestCase):
         )
 
     @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test_redfish_logout_401(self, mock_redfish_client):
-        """Test that exception is not raised if logout fails with 401."""
+    def test_redfish_logout_bad_request(self, mock_redfish_client):
+        """Test that exception is not raised if redfish logout fails."""
         mock_redfish_obj = Mock()
         mock_redfish_obj.logout.side_effect = BadRequestError(
             "Invalid session resource: /redfish/v1/SessionService/Sessions/132562, "
@@ -1108,16 +1108,3 @@ class TestRedfishServiceDiscovery(unittest.TestCase):
         mock_redfish_client.return_value = mock_redfish_obj
         with RedfishHelper(Mock()) as redfish_helper:
             self.assertIsNone(redfish_helper.logout())
-
-    @patch("prometheus_hardware_exporter.collectors.redfish.redfish_client")
-    def test_redfish_logout_error(self, mock_redfish_client):
-        """Test that exception is raised if logout fails with response not 401."""
-        mock_redfish_obj = Mock()
-        mock_redfish_obj.logout.side_effect = BadRequestError(
-            "Invalid session resource: /redfish/v1/SessionService/Sessions/132562, "
-            "return code: 404"
-        )
-        mock_redfish_client.return_value = mock_redfish_obj
-        redfish_helper = RedfishHelper(Mock())
-        with self.assertRaises(BadRequestError):
-            redfish_helper.logout()


### PR DESCRIPTION
Redfish sometimes fails to logout after scraping the data and this end up generating the metric `redfish_collector_failed` that trigger prometheus alerts that can be noise for production clouds.

This can be a BMC problem that might not be properly closing sessions.

For more info see:
https://github.com/DMTF/python-redfish-library/issues/160

Closes: #76