### PR TITLE
Allow users to change driver to collect ipmi metrics

### DIFF
--- a/prometheus_hardware_exporter/__main__.py
+++ b/prometheus_hardware_exporter/__main__.py
@@ -53,26 +53,26 @@ def parse_command_line() -> argparse.Namespace:
         type=int,
     )
     parser.add_argument(
-        "--hostname",
+        "--redfish-host",
         help="Hostname of the bmc/ipmi device",
         default="",
         type=str,
     )
     parser.add_argument(
-        "--username",
-        help="BMC username",
+        "--redfish-username",
+        help="Username of the bmc/ipmi device",
         default="",
         type=str,
     )
     parser.add_argument(
-        "--password",
-        help="BMC password",
+        "--redfish-password",
+        help="Password of the bmc/ipmi device",
         default="",
         type=str,
     )
     parser.add_argument(
         "--driver-type",
-        help="Specify the driver type to use instead of doing an auto selection. Use LAN_2_0 for ipmi over LAN.",
+        help="Specify the driver type to be used for ipmi. Use LAN_2_0 for ipmi over LAN.",
         default="",
         type=str,
     )
@@ -204,9 +204,9 @@ def main() -> None:
             port=namespace.port,
             level=namespace.level,
             enable_collectors=collectors,
-            hostname=namespace.hostname,
-            username=namespace.username,
-            password=namespace.password,
+            hostname=namespace.redfish_host,
+            username=namespace.redfish_username,
+            password=namespace.redfish_password,
             driver_type=namespace.driver_type,
             ipmi_sel_interval=namespace.ipmi_sel_interval,
             redfish_client_timeout=namespace.redfish_client_timeout,

--- a/prometheus_hardware_exporter/__main__.py
+++ b/prometheus_hardware_exporter/__main__.py
@@ -24,6 +24,7 @@ from .config import (
     DEFAULT_REDFISH_CLIENT_TIMEOUT,
     DEFAULT_REDFISH_DISCOVER_CACHE_TTL,
     Config,
+    get_bmc_address,
 )
 from .exporter import Exporter
 
@@ -52,20 +53,26 @@ def parse_command_line() -> argparse.Namespace:
         type=int,
     )
     parser.add_argument(
-        "--redfish-host",
-        help="Hostname for redfish collector",
-        default="127.0.0.1",
-        type=str,
-    )
-    parser.add_argument(
-        "--redfish-username",
-        help="BMC username for redfish collector",
+        "--hostname",
+        help="Hostname of the bmc/ipmi device",
         default="",
         type=str,
     )
     parser.add_argument(
-        "--redfish-password",
-        help="BMC password for redfish collector",
+        "--username",
+        help="BMC username",
+        default="",
+        type=str,
+    )
+    parser.add_argument(
+        "--password",
+        help="BMC password",
+        default="",
+        type=str,
+    )
+    parser.add_argument(
+        "--driver-type",
+        help="Specify the driver type to use instead of doing an auto selection. Use LAN_2_0 for ipmi over LAN.",
         default="",
         type=str,
     )
@@ -197,15 +204,25 @@ def main() -> None:
             port=namespace.port,
             level=namespace.level,
             enable_collectors=collectors,
-            redfish_host=namespace.redfish_host,
-            redfish_username=namespace.redfish_username,
-            redfish_password=namespace.redfish_password,
+            hostname=namespace.hostname,
+            username=namespace.username,
+            password=namespace.password,
+            driver_type=namespace.driver_type,
             ipmi_sel_interval=namespace.ipmi_sel_interval,
             redfish_client_timeout=namespace.redfish_client_timeout,
             redfish_client_max_retry=namespace.redfish_client_max_retry,
             redfish_discover_cache_ttl=namespace.redfish_discover_cache_ttl,
             collect_timeout=namespace.collect_timeout,
         )
+
+        # If hostname is empty, try to resolve BMC IP via ipmitool
+        if not exporter_config.hostname:
+            host = get_bmc_address()
+            if host is not None:
+                exporter_config.hostname = host
+                logger.info("Resolved hostname from ipmitool: %s", host)
+            else:
+                logger.warning("Hostname is not provided and cannot be resolved from ipmitool.")
 
     # Start the exporter
     start_exporter(exporter_config)

--- a/prometheus_hardware_exporter/__main__.py
+++ b/prometheus_hardware_exporter/__main__.py
@@ -10,6 +10,7 @@ from .collector import (
     IpmiDcmiCollector,
     IpmiSelCollector,
     IpmiSensorsCollector,
+    IpmiTool,
     LSISASControllerCollector,
     MegaRAIDCollector,
     PowerEdgeRAIDCollector,
@@ -24,7 +25,6 @@ from .config import (
     DEFAULT_REDFISH_CLIENT_TIMEOUT,
     DEFAULT_REDFISH_DISCOVER_CACHE_TTL,
     Config,
-    get_bmc_address,
 )
 from .exporter import Exporter
 
@@ -217,7 +217,7 @@ def main() -> None:
 
         # If hostname is empty, try to resolve BMC IP via ipmitool
         if not exporter_config.hostname:
-            host = get_bmc_address()
+            host = IpmiTool(exporter_config).get_ipmi_host()
             if host is not None:
                 exporter_config.hostname = host
                 logger.info("Resolved hostname from ipmitool: %s", host)

--- a/prometheus_hardware_exporter/collector.py
+++ b/prometheus_hardware_exporter/collector.py
@@ -369,8 +369,8 @@ class IpmiDcmiCollector(BlockingCollector):
 
     def fetch(self) -> List[Payload]:
         """Load current power from ipmi dcmi power statistics."""
-        bmc_host = self.ipmitool.get_ipmi_host() or "unknown"
         current_power_payload = self.ipmi_dcmi.get_current_power()
+        bmc_host = self.config.hostname or "unknown"
 
         if not current_power_payload:
             logger.error("Failed to fetch current power from ipmi dcmi")
@@ -435,7 +435,6 @@ class IpmiSensorsCollector(BlockingCollector):
     def __init__(self, config: Config) -> None:
         """Initialize the collector."""
         self.ipmimonitoring = IpmiMonitoring(config)
-        self.ipmitool = IpmiTool(config)
         super().__init__(config)
 
     @property
@@ -494,7 +493,7 @@ class IpmiSensorsCollector(BlockingCollector):
 
     def fetch(self) -> List[Payload]:
         """Load ipmi sensors data."""
-        bmc_host = self.ipmitool.get_ipmi_host() or "unknown"
+        bmc_host = self.config.hostname or "unknown"
         sensor_data = self.ipmimonitoring.get_sensor_data()
 
         if not sensor_data:
@@ -676,7 +675,7 @@ class IpmiSelCollector(NonBlockingCollector):
 
     def fetch(self) -> List[Payload]:
         """Load ipmi sel entries."""
-        bmc_host = self.ipmitool.get_ipmi_host() or "unknown"
+        bmc_host = self.config.hostname or "unknown"
 
         if self.is_cache_expired():
             logger.warning("Cache for ipmi sel is expired.")
@@ -1090,7 +1089,7 @@ class RedfishCollector(BlockingCollector):
         """Load redfish data."""
         payloads: List[Payload] = []
 
-        service_status = self.discover_redfish_services(self.config.redfish_host)
+        service_status = self.discover_redfish_services(self.config.hostname)
         payloads.append(Payload(name="redfish_service_available", value=float(service_status)))
         if not service_status:
             return payloads

--- a/prometheus_hardware_exporter/collectors/ipmi_dcmi.py
+++ b/prometheus_hardware_exporter/collectors/ipmi_dcmi.py
@@ -2,9 +2,9 @@
 
 import re
 from logging import getLogger
-from typing import Dict, Optional, Tuple
+from typing import Dict, Tuple
 
-from ..utils import Command
+from ..utils import Command, ipmi_over_lan_args
 
 logger = getLogger(__name__)
 
@@ -36,22 +36,6 @@ class IpmiTool(Command):
                 output.append(data[4])
         return True, all(status == "Fully Redundant" for status in output) | False
 
-    def get_ipmi_host(self) -> Optional[str]:
-        """Get IPMI host name.
-
-        returns:
-            hostname - IPMI/BMC host or None
-        """
-        result = self("lan print")
-        if result.error:
-            logger.error(result.error)
-            return None
-        for line in result.data.splitlines():
-            if "IP Address" in line and "Source" not in line:
-                _, ip_address = line.split(":", 1)
-                return ip_address.strip()
-        return None
-
 
 class IpmiDcmi(Command):
     """Command line tool for ipmi dcmi."""
@@ -65,7 +49,8 @@ class IpmiDcmi(Command):
         Returns:
             payload: a dictionary containing current_power, or {}
         """
-        result = self("--get-system-power-statistics")
+        args = "--get-system-power-statistics" + ipmi_over_lan_args(self.config)
+        result = self(args)
         if result.error:
             logger.error(result.error)
             return {}

--- a/prometheus_hardware_exporter/collectors/ipmi_dcmi.py
+++ b/prometheus_hardware_exporter/collectors/ipmi_dcmi.py
@@ -2,7 +2,7 @@
 
 import re
 from logging import getLogger
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from ..utils import Command, ipmi_over_lan_args
 
@@ -35,6 +35,22 @@ class IpmiTool(Command):
                 # column 4 is redundancy status
                 output.append(data[4])
         return True, all(status == "Fully Redundant" for status in output) | False
+
+    def get_ipmi_host(self) -> Optional[str]:
+        """Get IPMI host name.
+
+        returns:
+            hostname - IPMI/BMC host or None
+        """
+        result = self("lan print")
+        if result.error:
+            logger.error(result.error)
+            return None
+        for line in result.data.splitlines():
+            if "IP Address" in line and "Source" not in line:
+                _, ip_address = line.split(":", 1)
+                return ip_address.strip()
+        return None
 
 
 class IpmiDcmi(Command):

--- a/prometheus_hardware_exporter/collectors/ipmi_dcmi.py
+++ b/prometheus_hardware_exporter/collectors/ipmi_dcmi.py
@@ -49,8 +49,8 @@ class IpmiDcmi(Command):
         Returns:
             payload: a dictionary containing current_power, or {}
         """
-        args = "--get-system-power-statistics" + ipmi_over_lan_args(self.config)
-        result = self(args)
+        args = ["--get-system-power-statistics", *ipmi_over_lan_args(self.config)]
+        result = self(" ".join(args))
         if result.error:
             logger.error(result.error)
             return {}

--- a/prometheus_hardware_exporter/collectors/ipmi_sel.py
+++ b/prometheus_hardware_exporter/collectors/ipmi_sel.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from typing import Dict, List, Optional
 
 from ..config import Config
-from ..utils import Command
+from ..utils import Command, ipmi_over_lan_args
 
 logger = getLogger(__name__)
 
@@ -32,9 +32,11 @@ class IpmiSel(Command):
         # --sdr-cache-recreate is required to automatically recreate the SDR cache in case it is
         # out of date or invalid. Without this, the service will stop getting ipmi-sel data if the
         # cache is out of date.
-        result = self(
+        args = (
             "--sdr-cache-recreate --output-event-state --interpret-oem-data --entity-sensor-names"
+            + ipmi_over_lan_args(self.config)
         )
+        result = self(args)
         if result.error:
             logger.error(result.error)
             return None

--- a/prometheus_hardware_exporter/collectors/ipmi_sel.py
+++ b/prometheus_hardware_exporter/collectors/ipmi_sel.py
@@ -32,11 +32,14 @@ class IpmiSel(Command):
         # --sdr-cache-recreate is required to automatically recreate the SDR cache in case it is
         # out of date or invalid. Without this, the service will stop getting ipmi-sel data if the
         # cache is out of date.
-        args = (
-            "--sdr-cache-recreate --output-event-state --interpret-oem-data --entity-sensor-names"
-            + ipmi_over_lan_args(self.config)
-        )
-        result = self(args)
+        args = [
+            "--sdr-cache-recreate",
+            "--output-event-state",
+            "--interpret-oem-data",
+            "--entity-sensor-names",
+            *ipmi_over_lan_args(self.config),
+        ]
+        result = self(" ".join(args))
         if result.error:
             logger.error(result.error)
             return None

--- a/prometheus_hardware_exporter/collectors/ipmimonitoring.py
+++ b/prometheus_hardware_exporter/collectors/ipmimonitoring.py
@@ -3,7 +3,7 @@
 from logging import getLogger
 from typing import Dict, List
 
-from ..utils import Command
+from ..utils import Command, ipmi_over_lan_args
 
 logger = getLogger(__name__)
 
@@ -14,7 +14,7 @@ class IpmiMonitoring(Command):
     prefix = ""
     command = "ipmimonitoring"
 
-    def get_sensor_data(self) -> List[Dict[str, str]]:
+    def get_sensor_data(self, hostname: str) -> List[Dict[str, str]]:
         """Get sensor data.
 
         Returns:
@@ -23,7 +23,8 @@ class IpmiMonitoring(Command):
         # --sdr-cache-recreate is required to automatically recreate the SDR cache in case it is
         # out of date or invalid. Without this, the service will stop getting sensor data if the
         # cache is out of date.
-        result = self("--sdr-cache-recreate")
+        args = "--sdr-cache-recreate " + ipmi_over_lan_args(self.config)
+        result = self(args)
         if result.error:
             logger.error(result.error)
             return []

--- a/prometheus_hardware_exporter/collectors/ipmimonitoring.py
+++ b/prometheus_hardware_exporter/collectors/ipmimonitoring.py
@@ -14,7 +14,7 @@ class IpmiMonitoring(Command):
     prefix = ""
     command = "ipmimonitoring"
 
-    def get_sensor_data(self, hostname: str) -> List[Dict[str, str]]:
+    def get_sensor_data(self) -> List[Dict[str, str]]:
         """Get sensor data.
 
         Returns:
@@ -23,8 +23,8 @@ class IpmiMonitoring(Command):
         # --sdr-cache-recreate is required to automatically recreate the SDR cache in case it is
         # out of date or invalid. Without this, the service will stop getting sensor data if the
         # cache is out of date.
-        args = "--sdr-cache-recreate " + ipmi_over_lan_args(self.config)
-        result = self(args)
+        args = ["--sdr-cache-recreate", *ipmi_over_lan_args(self.config)]
+        result = self(" ".join(args))
         if result.error:
             logger.error(result.error)
             return []

--- a/prometheus_hardware_exporter/collectors/redfish.py
+++ b/prometheus_hardware_exporter/collectors/redfish.py
@@ -70,9 +70,9 @@ class RedfishHelper:
     def __init__(self, config: Config) -> None:
         """Initialize values for class."""
         self.redfish_obj = redfish_client(
-            base_url=config.redfish_host,
-            username=config.redfish_username,
-            password=config.redfish_password,
+            base_url=config.hostname,
+            username=config.username,
+            password=config.password,
             timeout=config.redfish_client_timeout,
             max_retry=config.redfish_client_max_retry,
         )

--- a/prometheus_hardware_exporter/config.py
+++ b/prometheus_hardware_exporter/config.py
@@ -127,14 +127,4 @@ class Config(BaseModel):
         with open(config_file, "r", encoding="utf-8") as config:
             logger.info("Loaded exporter configuration: %s.", config_file)
             data = safe_load(config) or {}
-            conf = cls(**data)
-            # If hostname not provided, try to resolve from local ipmitool
-            if not conf.hostname:
-                try:
-                    host = get_bmc_address()
-                    if host:
-                        conf.hostname = host
-                        logger.info("Resolved hostname from ipmitool: %s", host)
-                except Exception:  # pragma: no cover - best-effort
-                    logger.debug("Unable to resolve hostname via ipmitool")
-            return conf
+            return cls(**data)

--- a/prometheus_hardware_exporter/config.py
+++ b/prometheus_hardware_exporter/config.py
@@ -1,7 +1,6 @@
 """Module for hardware exporter related configuration."""
 
 import os
-import subprocess
 from logging import getLogger
 from typing import List, Optional
 
@@ -22,20 +21,6 @@ DEFAULT_IPMI_SEL_CACHE_TTL = 600
 
 
 # pylint: disable=E0213
-
-
-def get_bmc_address() -> Optional[str]:
-    """Get BMC IP address by ipmitool."""
-    cmd = "ipmitool lan print"
-    try:
-        output = subprocess.check_output(cmd.split(), text=True)
-        for line in output.splitlines():
-            values = line.split(":")
-            if values[0].strip() == "IP Address":
-                return values[1].strip()
-    except subprocess.CalledProcessError:
-        logger.debug("IPMI is not available")
-    return None
 
 
 class Config(BaseModel):

--- a/prometheus_hardware_exporter/config.py
+++ b/prometheus_hardware_exporter/config.py
@@ -1,6 +1,7 @@
 """Module for hardware exporter related configuration."""
 
 import os
+import subprocess
 from logging import getLogger
 from typing import List, Optional
 
@@ -19,14 +20,29 @@ DEFAULT_REDFISH_CLIENT_MAX_RETRY = 1
 DEFAULT_REDFISH_DISCOVER_CACHE_TTL = 86400
 DEFAULT_IPMI_SEL_CACHE_TTL = 600
 
+
 # pylint: disable=E0213
+
+
+def get_bmc_address() -> Optional[str]:
+    """Get BMC IP address by ipmitool."""
+    cmd = "ipmitool lan print"
+    try:
+        output = subprocess.check_output(cmd.split(), text=True)
+        for line in output.splitlines():
+            values = line.split(":")
+            if values[0].strip() == "IP Address":
+                return values[1].strip()
+    except subprocess.CalledProcessError:
+        logger.debug("IPMI is not available")
+    return None
 
 
 class Config(BaseModel):
     """Hardware exporter configuration."""
 
     port: int = 10000
-    level: str = "DEBUG"
+    level: str = "INFO"
     enable_collectors: List[str] = []
 
     collect_timeout: Optional[int] = DEFAULT_COLLECT_TIMEOUT
@@ -34,9 +50,10 @@ class Config(BaseModel):
     ipmi_sel_collect_interval: int = DEFAULT_IPMI_SEL_COLLECT_INTERVAL
     ipmi_sel_cache_ttl: int = DEFAULT_IPMI_SEL_CACHE_TTL
 
-    redfish_host: str = "127.0.0.1"
-    redfish_username: str = ""
-    redfish_password: str = ""
+    hostname: str = ""
+    username: str = ""
+    password: str = ""
+    driver_type: str = ""
     redfish_client_timeout: int = DEFAULT_REDFISH_CLIENT_TIMEOUT
     redfish_client_max_retry: int = DEFAULT_REDFISH_CLIENT_MAX_RETRY
     redfish_discover_cache_ttl: int = DEFAULT_REDFISH_DISCOVER_CACHE_TTL
@@ -88,6 +105,18 @@ class Config(BaseModel):
             raise ValueError(msg)
         return enable_collectors
 
+    @validator("driver_type")
+    @classmethod
+    def validate_driver_type_choice(cls, driver_type: str) -> str:
+        """Validate driver type choice."""
+        driver = driver_type.upper()
+        choices = {"LAN", "LAN_2_0", "KCS", "SSIF", "OPENIPMI", "SUNBMC", ""}
+        if driver not in choices:
+            msg = f"Driver type must be in {choices} (case-insensitive)."
+            logger.error(msg)
+            raise ValueError(msg)
+        return driver_type
+
     @classmethod
     def load_config(cls, config_file: str = DEFAULT_CONFIG) -> "Config":
         """Load configuration file and validate it."""
@@ -98,4 +127,14 @@ class Config(BaseModel):
         with open(config_file, "r", encoding="utf-8") as config:
             logger.info("Loaded exporter configuration: %s.", config_file)
             data = safe_load(config) or {}
-            return cls(**data)
+            conf = cls(**data)
+            # If hostname not provided, try to resolve from local ipmitool
+            if not conf.hostname:
+                try:
+                    host = get_bmc_address()
+                    if host:
+                        conf.hostname = host
+                        logger.info("Resolved hostname from ipmitool: %s", host)
+                except Exception:  # pragma: no cover - best-effort
+                    logger.debug("Unable to resolve hostname via ipmitool")
+            return conf

--- a/prometheus_hardware_exporter/utils.py
+++ b/prometheus_hardware_exporter/utils.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 from dataclasses import dataclass
 from logging import getLogger
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from .config import Config
 
@@ -86,18 +86,21 @@ def get_json_output(content: str) -> Union[dict, Exception]:
         return err
 
 
-def ipmi_over_lan_args(config: Config) -> str:
+def ipmi_over_lan_args(config: Config) -> List[str]:
     """Get IPMI over LAN arguments for ipmitool commands."""
     if "LAN" not in config.driver_type.upper():
         return []
 
-    return [
-        "-D",
-        config.driver_type,
-        "-h",
-        config.hostname,
-        "-u",
-        config.username,
-        "-p",
-        config.password,
-    ]
+    args = ["-D", config.driver_type]
+
+    optional_args = {
+        "-h": config.hostname,
+        "-u": config.username,
+        "-p": config.password,
+    }
+
+    for flag, value in optional_args.items():
+        if value:
+            args.extend([flag, value])
+
+    return args

--- a/prometheus_hardware_exporter/utils.py
+++ b/prometheus_hardware_exporter/utils.py
@@ -88,7 +88,16 @@ def get_json_output(content: str) -> Union[dict, Exception]:
 
 def ipmi_over_lan_args(config: Config) -> str:
     """Get IPMI over LAN arguments for ipmitool commands."""
-    cmd = ""
-    if "LAN" in config.driver_type.upper():
-        cmd += f" -D {config.driver_type} -h {config.hostname} -u {config.username} -p {config.password} "
-    return cmd
+    if "LAN" not in config.driver_type.upper():
+        return []
+
+    return [
+        "-D",
+        config.driver_type,
+        "-h",
+        config.hostname,
+        "-u",
+        config.username,
+        "-p",
+        config.password,
+    ]

--- a/prometheus_hardware_exporter/utils.py
+++ b/prometheus_hardware_exporter/utils.py
@@ -84,3 +84,11 @@ def get_json_output(content: str) -> Union[dict, Exception]:
         return data
     except ValueError as err:
         return err
+
+
+def ipmi_over_lan_args(config: Config) -> str:
+    """Get IPMI over LAN arguments for ipmitool commands."""
+    cmd = ""
+    if "LAN" in config.driver_type.upper():
+        cmd += f" -D {config.driver_type} -h {config.hostname} -u {config.username} -p {config.password} "
+    return cmd

--- a/tests/functional/test_package.py
+++ b/tests/functional/test_package.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 """Test prometheus-hardware-exporter package."""
+
 from subprocess import run
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -105,3 +105,63 @@ def test_get_collector_registries():
             "collector.redfish",
         ]
     )
+
+
+@patch.object(__main__, "get_bmc_address")
+@patch.object(__main__, "start_exporter")
+@patch.object(__main__, "parse_command_line")
+def test_main_resolves_hostname_from_ipmitool(mock_parse_cli, mock_start_exporter, mock_get_bmc):
+    """When no hostname provided, main should resolve it via get_bmc_address."""
+    mock_ns = Mock()
+    mock_ns.config = False
+    mock_ns.port = 10000
+    mock_ns.level = "INFO"
+    mock_ns.redfish_host = ""
+    mock_ns.redfish_username = ""
+    mock_ns.redfish_password = ""
+    mock_ns.driver_type = ""
+    mock_ns.ipmi_sel_interval = 0
+    mock_ns.redfish_client_timeout = 15
+    mock_ns.redfish_client_max_retry = 1
+    mock_ns.redfish_discover_cache_ttl = 86400
+    mock_ns.collect_timeout = 30
+    mock_parse_cli.return_value = mock_ns
+
+    mock_get_bmc.return_value = "1.2.3.4"
+
+    main()
+
+    mock_get_bmc.assert_called_once()
+    assert mock_start_exporter.called
+    exporter_config = mock_start_exporter.call_args[0][0]
+    assert exporter_config.hostname == "1.2.3.4"
+
+
+@patch.object(__main__, "get_bmc_address")
+@patch.object(__main__, "start_exporter")
+@patch.object(__main__, "parse_command_line")
+def test_main_hostname_unresolved_warns(mock_parse_cli, mock_start_exporter, mock_get_bmc):
+    """When get_bmc_address returns None, hostname remains empty."""
+    mock_ns = Mock()
+    mock_ns.config = False
+    mock_ns.port = 10000
+    mock_ns.level = "INFO"
+    mock_ns.redfish_host = ""
+    mock_ns.redfish_username = ""
+    mock_ns.redfish_password = ""
+    mock_ns.driver_type = ""
+    mock_ns.ipmi_sel_interval = 0
+    mock_ns.redfish_client_timeout = 15
+    mock_ns.redfish_client_max_retry = 1
+    mock_ns.redfish_discover_cache_ttl = 86400
+    mock_ns.collect_timeout = 30
+    mock_parse_cli.return_value = mock_ns
+
+    mock_get_bmc.return_value = None
+
+    main()
+
+    mock_get_bmc.assert_called_once()
+    assert mock_start_exporter.called
+    exporter_config = mock_start_exporter.call_args[0][0]
+    assert exporter_config.hostname == ""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -9,6 +9,7 @@ from prometheus_hardware_exporter.__main__ import (
     parse_command_line,
     start_exporter,
 )
+from prometheus_hardware_exporter.collectors.ipmi_dcmi import IpmiTool
 from prometheus_hardware_exporter.config import Config
 
 
@@ -107,7 +108,7 @@ def test_get_collector_registries():
     )
 
 
-@patch.object(__main__, "get_bmc_address")
+@patch.object(IpmiTool, "get_ipmi_host")
 @patch.object(__main__, "start_exporter")
 @patch.object(__main__, "parse_command_line")
 def test_main_resolves_hostname_from_ipmitool(mock_parse_cli, mock_start_exporter, mock_get_bmc):
@@ -137,7 +138,7 @@ def test_main_resolves_hostname_from_ipmitool(mock_parse_cli, mock_start_exporte
     assert exporter_config.hostname == "1.2.3.4"
 
 
-@patch.object(__main__, "get_bmc_address")
+@patch.object(IpmiTool, "get_ipmi_host")
 @patch.object(__main__, "start_exporter")
 @patch.object(__main__, "parse_command_line")
 def test_main_hostname_unresolved_warns(mock_parse_cli, mock_start_exporter, mock_get_bmc):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 import pytest
 
 from prometheus_hardware_exporter.__main__ import Config
+from prometheus_hardware_exporter.config import get_bmc_address
+import subprocess
 
 
 class TestConfig(unittest.TestCase):
@@ -54,6 +56,16 @@ class TestConfig(unittest.TestCase):
             "port": mock_port,
             "level": mock_level,
             "enable_collectors": mock_enable_collectors,
+            "driver_type": "LAN_2_0"
+        }
+        with pytest.raises(ValueError):
+            Config.load_config()
+
+    @patch("prometheus_hardware_exporter.config.safe_load")
+    def test_invalid_driver_config(self, mock_safe_load):
+        """Test invalid driver config."""
+        mock_safe_load.return_value = {
+            "driver_type": "RANDOM",
         }
         with pytest.raises(ValueError):
             Config.load_config()
@@ -64,3 +76,26 @@ class TestConfig(unittest.TestCase):
         self.patch_os_path_exists.stop()
         with pytest.raises(ValueError):
             Config.load_config("random")
+
+
+@patch("prometheus_hardware_exporter.config.subprocess.check_output")
+def test_get_bmc_address_success(mock_check_output):
+    """get_bmc_address should return IP when ipmitool prints it."""
+    mock_check_output.return_value = (
+        "Some header\nIP Address              : 1.2.3.4\nOther: value"
+    )
+    assert get_bmc_address() == "1.2.3.4"
+
+
+@patch("prometheus_hardware_exporter.config.subprocess.check_output")
+def test_get_bmc_address_failure(mock_check_output):
+    """get_bmc_address should return None when ipmitool is unavailable."""
+    mock_check_output.side_effect = subprocess.CalledProcessError(1, "ipmitool")
+    assert get_bmc_address() is None
+
+
+@patch("prometheus_hardware_exporter.config.subprocess.check_output")
+def test_get_bmc_address_no_host(mock_check_output):
+    """get_bmc_address should return None when no IP Address line present."""
+    mock_check_output.return_value = "No ip information here\nAnother line"
+    assert get_bmc_address() is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,11 +1,9 @@
-import subprocess
 import unittest
 from unittest.mock import patch
 
 import pytest
 
 from prometheus_hardware_exporter.__main__ import Config
-from prometheus_hardware_exporter.config import get_bmc_address
 
 
 class TestConfig(unittest.TestCase):
@@ -76,24 +74,3 @@ class TestConfig(unittest.TestCase):
         self.patch_os_path_exists.stop()
         with pytest.raises(ValueError):
             Config.load_config("random")
-
-
-@patch("prometheus_hardware_exporter.config.subprocess.check_output")
-def test_get_bmc_address_success(mock_check_output):
-    """get_bmc_address should return IP when ipmitool prints it."""
-    mock_check_output.return_value = "Some header\nIP Address              : 1.2.3.4\nOther: value"
-    assert get_bmc_address() == "1.2.3.4"
-
-
-@patch("prometheus_hardware_exporter.config.subprocess.check_output")
-def test_get_bmc_address_failure(mock_check_output):
-    """get_bmc_address should return None when ipmitool is unavailable."""
-    mock_check_output.side_effect = subprocess.CalledProcessError(1, "ipmitool")
-    assert get_bmc_address() is None
-
-
-@patch("prometheus_hardware_exporter.config.subprocess.check_output")
-def test_get_bmc_address_no_host(mock_check_output):
-    """get_bmc_address should return None when no IP Address line present."""
-    mock_check_output.return_value = "No ip information here\nAnother line"
-    assert get_bmc_address() is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,3 +1,4 @@
+import subprocess
 import unittest
 from unittest.mock import patch
 
@@ -5,7 +6,6 @@ import pytest
 
 from prometheus_hardware_exporter.__main__ import Config
 from prometheus_hardware_exporter.config import get_bmc_address
-import subprocess
 
 
 class TestConfig(unittest.TestCase):
@@ -56,7 +56,7 @@ class TestConfig(unittest.TestCase):
             "port": mock_port,
             "level": mock_level,
             "enable_collectors": mock_enable_collectors,
-            "driver_type": "LAN_2_0"
+            "driver_type": "LAN_2_0",
         }
         with pytest.raises(ValueError):
             Config.load_config()
@@ -81,9 +81,7 @@ class TestConfig(unittest.TestCase):
 @patch("prometheus_hardware_exporter.config.subprocess.check_output")
 def test_get_bmc_address_success(mock_check_output):
     """get_bmc_address should return IP when ipmitool prints it."""
-    mock_check_output.return_value = (
-        "Some header\nIP Address              : 1.2.3.4\nOther: value"
-    )
+    mock_check_output.return_value = "Some header\nIP Address              : 1.2.3.4\nOther: value"
     assert get_bmc_address() == "1.2.3.4"
 
 

--- a/tests/unit/test_ipmi_dcmi.py
+++ b/tests/unit/test_ipmi_dcmi.py
@@ -76,27 +76,3 @@ class TestIpmiTool(unittest.TestCase):
         ipmitool = IpmiTool(config)
         ps_redundancy = ipmitool.get_ps_redundancy()
         self.assertEqual(ps_redundancy, (True, False))
-
-    @patch.object(Command, "__call__")
-    def test_03_get_ipmi_host_success(self, mock_call):
-        mock_call.return_value = Result(IPMITOOL_LAN_PRINT_SAMPLE_OUTPUT, None)
-        config = Config()
-        ipmitool = IpmiTool(config)
-        ipmi_host = ipmitool.get_ipmi_host()
-        self.assertEqual(ipmi_host, "0.0.0.0")
-
-    @patch.object(Command, "__call__")
-    def test_04_get_ipmi_host_error(self, mock_call):
-        mock_call.return_value = Result("", True)
-        config = Config()
-        ipmitool = IpmiTool(config)
-        ipmi_host = ipmitool.get_ipmi_host()
-        self.assertEqual(ipmi_host, None)
-
-    @patch.object(Command, "__call__")
-    def test_04_get_ipmi_no_host(self, mock_call):
-        mock_call.return_value = Result("", None)
-        config = Config()
-        ipmitool = IpmiTool(config)
-        ipmi_host = ipmitool.get_ipmi_host()
-        self.assertEqual(ipmi_host, None)

--- a/tests/unit/test_ipmi_dcmi.py
+++ b/tests/unit/test_ipmi_dcmi.py
@@ -76,3 +76,27 @@ class TestIpmiTool(unittest.TestCase):
         ipmitool = IpmiTool(config)
         ps_redundancy = ipmitool.get_ps_redundancy()
         self.assertEqual(ps_redundancy, (True, False))
+
+    @patch.object(Command, "__call__")
+    def test_03_get_ipmi_host_success(self, mock_call):
+        mock_call.return_value = Result(IPMITOOL_LAN_PRINT_SAMPLE_OUTPUT, None)
+        config = Config()
+        ipmitool = IpmiTool(config)
+        ipmi_host = ipmitool.get_ipmi_host()
+        self.assertEqual(ipmi_host, "0.0.0.0")
+
+    @patch.object(Command, "__call__")
+    def test_04_get_ipmi_host_error(self, mock_call):
+        mock_call.return_value = Result("", True)
+        config = Config()
+        ipmitool = IpmiTool(config)
+        ipmi_host = ipmitool.get_ipmi_host()
+        self.assertEqual(ipmi_host, None)
+
+    @patch.object(Command, "__call__")
+    def test_04_get_ipmi_no_host(self, mock_call):
+        mock_call.return_value = Result("", None)
+        config = Config()
+        ipmitool = IpmiTool(config)
+        ipmi_host = ipmitool.get_ipmi_host()
+        self.assertEqual(ipmi_host, None)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -69,3 +69,35 @@ def test_get_json_output():
 def test_get_json_output_err():
     result = get_json_output("""{"a": 1, "b": 2}123""")
     assert isinstance(result, Exception)
+
+def test_ipmi_over_lan_args_with_lan():
+    """Returns LAN args when driver_type contains LAN."""
+    config = Config()
+    config.driver_type = "LAN"
+    config.hostname = "1.2.3.4"
+    config.username = "admin"
+    config.password = "pass"
+
+    args = utils.ipmi_over_lan_args(config)
+    assert isinstance(args, list)
+    assert args == [
+        "-D",
+        "LAN",
+        "-h",
+        "1.2.3.4",
+        "-u",
+        "admin",
+        "-p",
+        "pass",
+    ]
+
+def test_ipmi_over_lan_args_without_lan():
+    """Returns empty list when driver_type does not contain LAN."""
+    config = Config()
+    config.driver_type = "KCS"
+    config.hostname = "1.2.3.4"
+    config.username = "admin"
+    config.password = "pass"
+
+    args = utils.ipmi_over_lan_args(config)
+    assert args == []

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -93,6 +93,26 @@ def test_ipmi_over_lan_args_with_lan():
     ]
 
 
+def test_ipmi_over_lan_args_missing_user():
+    """Returns LAN args when driver_type contains LAN."""
+    config = Config()
+    config.driver_type = "LAN"
+    config.hostname = "1.2.3.4"
+    config.username = ""
+    config.password = "pass"
+
+    args = utils.ipmi_over_lan_args(config)
+    assert isinstance(args, list)
+    assert args == [
+        "-D",
+        "LAN",
+        "-h",
+        "1.2.3.4",
+        "-p",
+        "pass",
+    ]
+
+
 def test_ipmi_over_lan_args_without_lan():
     """Returns empty list when driver_type does not contain LAN."""
     config = Config()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -70,6 +70,7 @@ def test_get_json_output_err():
     result = get_json_output("""{"a": 1, "b": 2}123""")
     assert isinstance(result, Exception)
 
+
 def test_ipmi_over_lan_args_with_lan():
     """Returns LAN args when driver_type contains LAN."""
     config = Config()
@@ -90,6 +91,7 @@ def test_ipmi_over_lan_args_with_lan():
         "-p",
         "pass",
     ]
+
 
 def test_ipmi_over_lan_args_without_lan():
     """Returns empty list when driver_type does not contain LAN."""


### PR DESCRIPTION
Some servers like HPE can collect ipmi metrics just using out-band (LAN). This PR changes the arguments for collecting ipmi if the driver selected is outband using LAN

# How to test it

In testflinger get the `penguru` machine and run the exporter:

```shell
prometheus-hardware-exporter --redfish-host=<IP> --redfish-username=<MY_USER> --redfish-password=<MY_PASS> --collector.ipmi_dcmi --collector.ipmi_sel --collector.ipmi_sensor --driver-type=LAN_2_0
2026-01-23 17:11:53 INFO Starting IPMI SEL cache update thread.
2026-01-23 17:11:53 INFO collector.ipmi_dcmi is enabled
/sys/firmware/dmi/tables/smbios_entry_point: Permission denied
2026-01-23 17:11:54 INFO collector.ipmi_sel is enabled
2026-01-23 17:11:54 INFO collector.ipmi_sensor is enabled
2026-01-23 17:11:55 INFO Started prometheus hardware exporter at 0.0.0.0:10000.
```

After that is possible to collect the IPMI metrics:

```
# HELP ipmi_dcmi_power_consumption_watts Current power consumption in watts
# TYPE ipmi_dcmi_power_consumption_watts gauge
ipmi_dcmi_power_consumption_watts{bmc_host="<IP>"} 124.0
# HELP ipmi_dcmi_power_consumption_percentage Current power capacity usage as a percentage of the overall PSU budget
# TYPE ipmi_dcmi_power_consumption_percentage gauge
ipmi_dcmi_power_consumption_percentage{bmc_host="<IP>",get_ps_redundancy_ok="0",maximum_power_capacity="0",ps_redundancy="1"} 0.0
```

Without those changes the exporter fails like this:
```
2026-01-23 17:41:26 ERROR Command 'ipmi-dcmi --get-system-power-statistics' returned non-zero exit status 1.
2026-01-23 17:41:26 ERROR Command 'ipmi-dcmi --get-system-power-statistics' returned non-zero exit status 1.
2026-01-23 17:41:26 ERROR Failed to fetch current power from ipmi dcmi

2026-01-23 17:41:26 ERROR Command 'ipmimonitoring --sdr-cache-recreate' returned non-zero exit status 1.
2026-01-23 17:41:26 ERROR Command 'ipmimonitoring --sdr-cache-recreate' returned non-zero exit status 1.
2026-01-23 17:41:26 ERROR Failed to get ipmi sensor data.

```


Closes: #116 