### PR TITLE
feat: ipmitool power supply over lan

### DIFF
--- a/prometheus_hardware_exporter/__main__.py
+++ b/prometheus_hardware_exporter/__main__.py
@@ -53,19 +53,19 @@ def parse_command_line() -> argparse.Namespace:
         type=int,
     )
     parser.add_argument(
-        "--redfish-host",
+        "--hostname",
         help="Hostname of the bmc/ipmi device",
         default="",
         type=str,
     )
     parser.add_argument(
-        "--redfish-username",
+        "--username",
         help="Username of the bmc/ipmi device",
         default="",
         type=str,
     )
     parser.add_argument(
-        "--redfish-password",
+        "--password",
         help="Password of the bmc/ipmi device",
         default="",
         type=str,
@@ -204,9 +204,9 @@ def main() -> None:
             port=namespace.port,
             level=namespace.level,
             enable_collectors=collectors,
-            hostname=namespace.redfish_host,
-            username=namespace.redfish_username,
-            password=namespace.redfish_password,
+            hostname=namespace.hostname,
+            username=namespace.username,
+            password=namespace.password,
             driver_type=namespace.driver_type,
             ipmi_sel_interval=namespace.ipmi_sel_interval,
             redfish_client_timeout=namespace.redfish_client_timeout,

--- a/prometheus_hardware_exporter/collectors/ipmi_dcmi.py
+++ b/prometheus_hardware_exporter/collectors/ipmi_dcmi.py
@@ -4,7 +4,7 @@ import re
 from logging import getLogger
 from typing import Dict, Optional, Tuple
 
-from ..utils import Command, ipmi_over_lan_args
+from ..utils import Command, ipmi_over_lan_args, ipmitool_over_lan_args
 
 logger = getLogger(__name__)
 
@@ -24,7 +24,8 @@ class IpmiTool(Command):
             - ok - True if fetching redundancy info is successful
             - redundancy - True if redundancy is enabled
         """
-        result = self("""sdr type "Power Supply" -c""")
+        args = ["sdr", "type", "Power Supply", "-c", *ipmitool_over_lan_args(self.config)]
+        result = self(" ".join(args))
         if result.error:
             logger.error(result.error)
             return False, False

--- a/prometheus_hardware_exporter/utils.py
+++ b/prometheus_hardware_exporter/utils.py
@@ -104,3 +104,23 @@ def ipmi_over_lan_args(config: Config) -> List[str]:
             args.extend([flag, value])
 
     return args
+
+
+def ipmitool_over_lan_args(config: Config) -> List[str]:
+    """Get ipmitool over LAN arguments for ipmitool commands."""
+    if "LAN" not in config.driver_type.upper():
+        return []
+
+    args = ["-I", "lanplus"]
+
+    optional_args = {
+        "-H": config.hostname,
+        "-U": config.username,
+        "-P": config.password,
+    }
+
+    for flag, value in optional_args.items():
+        if value:
+            args.extend([flag, value])
+
+    return args

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -117,9 +117,9 @@ def test_main_resolves_hostname_from_ipmitool(mock_parse_cli, mock_start_exporte
     mock_ns.config = False
     mock_ns.port = 10000
     mock_ns.level = "INFO"
-    mock_ns.redfish_host = ""
-    mock_ns.redfish_username = ""
-    mock_ns.redfish_password = ""
+    mock_ns.hostname = ""
+    mock_ns.username = ""
+    mock_ns.password = ""
     mock_ns.driver_type = ""
     mock_ns.ipmi_sel_interval = 0
     mock_ns.redfish_client_timeout = 15
@@ -147,9 +147,9 @@ def test_main_hostname_unresolved_warns(mock_parse_cli, mock_start_exporter, moc
     mock_ns.config = False
     mock_ns.port = 10000
     mock_ns.level = "INFO"
-    mock_ns.redfish_host = ""
-    mock_ns.redfish_username = ""
-    mock_ns.redfish_password = ""
+    mock_ns.hostname = ""
+    mock_ns.username = ""
+    mock_ns.password = ""
     mock_ns.driver_type = ""
     mock_ns.ipmi_sel_interval = 0
     mock_ns.redfish_client_timeout = 15

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -123,3 +123,57 @@ def test_ipmi_over_lan_args_without_lan():
 
     args = utils.ipmi_over_lan_args(config)
     assert args == []
+
+
+def test_ipmitool_over_lan_args_with_lan():
+    """Returns LAN args for ipmitool when driver_type contains LAN."""
+    config = Config()
+    config.driver_type = "LAN"
+    config.hostname = "1.2.3.4"
+    config.username = "admin"
+    config.password = "pass"
+
+    args = utils.ipmitool_over_lan_args(config)
+    assert isinstance(args, list)
+    assert args == [
+        "-I",
+        "lanplus",
+        "-H",
+        "1.2.3.4",
+        "-U",
+        "admin",
+        "-P",
+        "pass",
+    ]
+
+
+def test_ipmitool_over_lan_args_missing_user():
+    """Skips username flag when username is empty for ipmitool."""
+    config = Config()
+    config.driver_type = "LAN"
+    config.hostname = "1.2.3.4"
+    config.username = ""
+    config.password = "pass"
+
+    args = utils.ipmitool_over_lan_args(config)
+    assert isinstance(args, list)
+    assert args == [
+        "-I",
+        "lanplus",
+        "-H",
+        "1.2.3.4",
+        "-P",
+        "pass",
+    ]
+
+
+def test_ipmitool_over_lan_args_without_lan():
+    """Returns empty list when driver_type does not contain LAN for ipmitool."""
+    config = Config()
+    config.driver_type = "KCS"
+    config.hostname = "1.2.3.4"
+    config.username = "admin"
+    config.password = "pass"
+
+    args = utils.ipmitool_over_lan_args(config)
+    assert args == []


### PR DESCRIPTION
Not having ipmitool power supply over lan can timeout the collector.

Unify the cli arguments to be usable for both redfish and ipmi